### PR TITLE
Trivial fixes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@ pub trait Context {
 
     unsafe fn buffer_data_size(&self, target: u32, size: i32, usage: u32);
 
-    unsafe fn buffer_data_u8_slice(&self, target: u32, data: &mut [u8], usage: u32);
+    unsafe fn buffer_data_u8_slice(&self, target: u32, data: &[u8], usage: u32);
 
     unsafe fn buffer_storage(&self, target: u32, size: i32, data: Option<&mut [u8]>, flags: u32);
 

--- a/src/native.rs
+++ b/src/native.rs
@@ -311,7 +311,7 @@ impl super::Context for Context {
         gl.BufferData(target, size as isize, std::ptr::null(), usage);
     }
 
-    unsafe fn buffer_data_u8_slice(&self, target: u32, data: &mut [u8], usage: u32) {
+    unsafe fn buffer_data_u8_slice(&self, target: u32, data: &[u8], usage: u32) {
         let gl = &self.raw;
         gl.BufferData(
             target,

--- a/src/native.rs
+++ b/src/native.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+use std::ffi::CString;
 use std::sync::Arc;
 
 mod native_gl {
@@ -711,6 +712,7 @@ impl super::Context for Context {
         name: &str,
     ) -> Option<Self::UniformLocation> {
         let gl = &self.raw;
+        let name = CString::new(name).unwrap();
         Some(gl.GetUniformLocation(program, name.as_ptr() as *const i8) as u32)
     }
     
@@ -720,6 +722,7 @@ impl super::Context for Context {
         name: &str
     ) -> i32 {
         let gl = &self.raw;
+        let name = CString::new(name).unwrap();
         gl.GetAttribLocation(program, name.as_ptr() as *const i8) as i32
     }
 

--- a/src/web.rs
+++ b/src/web.rs
@@ -501,7 +501,7 @@ impl super::Context for Context {
         }
     }
 
-    unsafe fn buffer_data_u8_slice(&self, target: u32, data: &mut [u8], usage: u32) {
+    unsafe fn buffer_data_u8_slice(&self, target: u32, data: &[u8], usage: u32) {
         match self.raw {
             RawRenderingContext::WebGl1(ref gl) => {
                 gl.buffer_data_with_u8_array(target, data, usage)


### PR DESCRIPTION
This PR includes:

* removal of `mut` keyword which is no longer needed
* convert Rust string into `CString` for passing null-terminated string to `glGetUniformLocartion()` and `glGetAttribLocation()`