### PR TITLE
Added SDL2 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,12 @@ name = "glow"
 path = "src/lib.rs"
 
 [target.'cfg(not(any(target_arch = "wasm32")))'.dependencies]
-glutin = "0.19"
+glutin = { version = "0.19", optional = true }
+sdl2 = { version = "0.32", optional = true }
+
+[features]
+default = ["glutin"]
+sdl = ["sdl2"]
 
 [target.wasm32-unknown-unknown.dependencies]
 js-sys = "0.3"

--- a/examples/hello/Cargo.toml
+++ b/examples/hello/Cargo.toml
@@ -7,7 +7,12 @@ edition = "2018"
 glow = { path = "../../" }
 
 [target.'cfg(not(any(target_arch = "wasm32")))'.dependencies]
-glutin = "0.19"
+glutin = { version = "0.19", optional = true }
+sdl2 = { version = "0.32", optional = true }
+
+[features]
+default = ["glutin"]
+sdl = ["sdl2", "glow/sdl2"]
 
 [target.wasm32-unknown-unknown.dependencies]
 web-sys = { version = "0.3", features=["console"] }

--- a/examples/hello/README.md
+++ b/examples/hello/README.md
@@ -6,6 +6,11 @@
 cargo run
 ```
 
+To use with sdl2
+```shell
+cargo run --no-default-featues --features=sdl
+```
+
 ## Web
 
 `cd` to `examples/hello` directory

--- a/src/native.rs
+++ b/src/native.rs
@@ -1261,6 +1261,12 @@ impl super::Context for Context {
     }
 }
 
+#[cfg(feature = "glutin")]
+pub type WindowType = glutin::GlWindow;
+
+#[cfg(feature = "sdl")]
+pub type WindowType = sdl2::video::Window;
+
 pub struct RenderLoop;
 
 impl RenderLoop {
@@ -1270,7 +1276,7 @@ impl RenderLoop {
 }
 
 impl super::RenderLoop for RenderLoop {
-    type Window = Arc<glutin::GlWindow>;
+    type Window = Arc<WindowType>;
 
     fn run<F: FnMut(&mut bool) + 'static>(&self, mut callback: F) {
         let mut running = true;


### PR DESCRIPTION
Added support for SDL2 using the feature `--no-default-features --features=sdl`. By default uses glutin on native targets. 