### PR TITLE
Add several methods required for glow backend after gfx-rs PR #2663

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ features = [
   "Document",
   "Element",
   "HtmlCanvasElement",
+  "WebGlActiveInfo",
   "WebGlBuffer",
   "WebGlFramebuffer",
   "WebGlProgram",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,12 @@ pub mod native;
 #[cfg(target_arch = "wasm32")]
 pub mod web;
 
+pub struct ActiveUniform {
+    pub size: i32,
+    pub utype: u32,
+    pub name: String,
+}
+
 pub trait Context {
     type Shader: Copy
         + Clone
@@ -122,6 +128,10 @@ pub trait Context {
 
     unsafe fn get_program_info_log(&self, program: Self::Program) -> String;
 
+    unsafe fn get_active_uniforms(&self, program: Self::Program) -> u32;
+
+    unsafe fn get_active_uniform(&self, program: Self::Program, index: u32) -> Option<ActiveUniform>;
+
     unsafe fn use_program(&self, program: Option<Self::Program>);
 
     unsafe fn create_buffer(&self) -> Result<Self::Buffer, String>;
@@ -140,6 +150,20 @@ pub trait Context {
     unsafe fn bind_framebuffer(&self, target: u32, framebuffer: Option<Self::Framebuffer>);
 
     unsafe fn bind_renderbuffer(&self, target: u32, renderbuffer: Option<Self::Renderbuffer>);
+
+    unsafe fn blit_framebuffer(
+        &self,
+        src_x0: i32,
+        src_y0: i32,
+        src_x1: i32,
+        src_y1: i32,
+        dst_x0: i32,
+        dst_y0: i32,
+        dst_x1: i32,
+        dst_y1: i32,
+        mask: u32,
+        filter: u32,
+    );
 
     unsafe fn create_vertex_array(&self) -> Result<Self::VertexArray, String>;
 

--- a/src/native.rs
+++ b/src/native.rs
@@ -190,6 +190,41 @@ impl super::Context for Context {
         }
     }
 
+    unsafe fn get_active_uniforms(&self, program: Self::Program) -> u32 {
+        let gl = &self.raw;
+        let mut count = 0;
+        gl.GetProgramiv(program, ACTIVE_UNIFORMS, &mut count);
+        count as u32
+    }
+
+    unsafe fn get_active_uniform(&self, program: Self::Program, index: u32) -> Option<ActiveUniform> {
+        let gl = &self.raw;
+        let mut uniform_max_size = 0;
+        gl.GetProgramiv(program, ACTIVE_UNIFORM_MAX_LENGTH, &mut uniform_max_size);
+
+        let mut name = String::with_capacity(uniform_max_size as usize);
+        name.extend(std::iter::repeat('\0').take(uniform_max_size as usize));
+        let mut length = 0;
+        let mut size = 0;
+        let mut utype = 0;
+        gl.GetActiveUniform(
+            program,
+            index,
+            uniform_max_size,
+            &mut length,
+            &mut size,
+            &mut utype,
+            name.as_ptr() as *mut native_gl::types::GLchar,
+        );
+        name.truncate(length as usize);
+        
+        Some(ActiveUniform {
+            size,
+            utype,
+            name,
+        })
+    }
+
     unsafe fn use_program(&self, program: Option<Self::Program>) {
         let gl = &self.raw;
         gl.UseProgram(program.unwrap_or(0));
@@ -233,6 +268,23 @@ impl super::Context for Context {
     unsafe fn bind_renderbuffer(&self, target: u32, renderbuffer: Option<Self::Renderbuffer>) {
         let gl = &self.raw;
         gl.BindRenderbuffer(target, renderbuffer.unwrap_or(0));
+    }
+
+    unsafe fn blit_framebuffer(
+        &self,
+        src_x0: i32,
+        src_y0: i32,
+        src_x1: i32,
+        src_y1: i32,
+        dst_x0: i32,
+        dst_y0: i32,
+        dst_x1: i32,
+        dst_y1: i32,
+        mask: u32,
+        filter: u32,
+    ) {
+        let gl = &self.raw;
+        gl.BlitFramebuffer(src_x0, src_y0, src_x1, src_y1, dst_x0, dst_y0, dst_x1, dst_y1, mask, filter);
     }
 
     unsafe fn create_vertex_array(&self) -> Result<Self::VertexArray, String> {


### PR DESCRIPTION
* Adds get_active_uniform, get_active_uniforms + descriptor structure
* Adds blit_framebuffer method (only on WebGL2)
* Implements bind_buffer_range, now unblocked by wasm-bindgen #1038 fix (only on
  WebGL2)
* Implements draw_buffer and draw_buffers, also unblocked by wasm-bindgen #1038
  fix (only on WebGL2)
* Only errors in polygon_mode if a mode other than GL_FILL is requested (In
  webgl / OpenGL ES the polygon mode is always GL_FILL?)