### PR TITLE
Add support for pixel buffer offset in get_tex_image

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,13 +105,22 @@ pub trait Context {
 
     unsafe fn get_shader_info_log(&self, shader: Self::Shader) -> String;
 
-    unsafe fn get_tex_image(
+    unsafe fn get_tex_image_u8_slice(
         &self,
         target: u32,
         level: i32,
         format: u32,
         ty: u32,
         pixels: Option<&[u8]>,
+    );
+
+    unsafe fn get_tex_image_pixel_buffer_offset(
+        &self,
+        target: u32,
+        level: i32,
+        format: u32,
+        ty: u32,
+        pixel_buffer_offset: i32,
     );
 
     unsafe fn create_program(&self) -> Result<Self::Program, String>;

--- a/src/native.rs
+++ b/src/native.rs
@@ -119,7 +119,7 @@ impl super::Context for Context {
         }
     }
 
-    unsafe fn get_tex_image(
+    unsafe fn get_tex_image_u8_slice(
         &self,
         target: u32,
         level: i32,
@@ -134,6 +134,24 @@ impl super::Context for Context {
             format,
             ty,
             pixels.map(|p| p.as_ptr()).unwrap_or(std::ptr::null()) as *mut std::ffi::c_void,
+        );
+    }
+
+    unsafe fn get_tex_image_pixel_buffer_offset(
+        &self,
+        target: u32,
+        level: i32,
+        format: u32,
+        ty: u32,
+        pixel_buffer_offset: i32,
+    ) {
+        let gl = &self.raw;
+        gl.GetTexImage(
+            target,
+            level,
+            format,
+            ty,
+            pixel_buffer_offset as *mut std::ffi::c_void,
         );
     }
 

--- a/src/web.rs
+++ b/src/web.rs
@@ -232,13 +232,24 @@ impl super::Context for Context {
         .unwrap_or_else(|| String::from(""))
     }
 
-    unsafe fn get_tex_image(
+    unsafe fn get_tex_image_u8_slice(
         &self,
         _target: u32,
         _level: i32,
         _format: u32,
         _ty: u32,
         _pixels: Option<&[u8]>,
+    ) {
+        panic!("Get tex image is not supported");
+    }
+
+    unsafe fn get_tex_image_pixel_buffer_offset(
+        &self,
+        _target: u32,
+        _level: i32,
+        _format: u32,
+        _ty: u32,
+        _pixel_buffer_offset: i32,
     ) {
         panic!("Get tex image is not supported");
     }


### PR DESCRIPTION
Necessary for this gfx PR: https://github.com/gfx-rs/gfx/pull/2822