### PR TITLE
Expose KHR_debug functionality in native contexts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,15 @@ pub struct ActiveUniform {
     pub name: String,
 }
 
+#[derive(Debug)]
+pub struct DebugMessageLogEntry {
+    source: u32,
+    msg_type: u32,
+    id: u32,
+    severity: u32,
+    message: String,
+}
+
 pub trait Context {
     type Shader: Copy
         + Clone
@@ -84,6 +93,7 @@ pub trait Context {
         + Ord
         + PartialEq
         + PartialOrd;
+    type DebugProc;
 
     unsafe fn create_framebuffer(&self) -> Result<Self::Framebuffer, String>;
 
@@ -684,6 +694,50 @@ pub trait Context {
     unsafe fn stencil_op(&self, stencil_fail: u32, depth_fail: u32, pass: u32);
 
     unsafe fn stencil_op_separate(&self, face: u32, stencil_fail: u32, depth_fail: u32, pass: u32);
+
+    unsafe fn debug_message_control(
+        &self,
+        source: u32,
+        msg_type: u32,
+        severity: u32,
+        ids: Option<&[u32]>,
+        enabled: bool,
+    );
+
+    unsafe fn debug_message_insert<S>(
+        &self,
+        source: u32,
+        msg_type: u32,
+        id: u32,
+        severity: u32,
+        msg: S,
+    ) where
+        S: AsRef<str>;
+
+    unsafe fn debug_message_callback(
+        &self,
+        callback: Self::DebugProc,
+        user_data: *mut std::ffi::c_void,
+    );
+
+    unsafe fn get_debug_message_log(
+        &self,
+        count: u32,
+    ) -> Vec<DebugMessageLogEntry>;
+
+    unsafe fn get_pointerv(&self, pname: u32, params: *const *mut std::ffi::c_void);
+
+    unsafe fn push_debug_group<S>(&self, source: u32, id: u32, message: S) where S: AsRef<str>;
+
+    unsafe fn pop_debug_group(&self);
+
+    unsafe fn object_label<S>(&self, identifier: u32, name: u32, label: S) where S: AsRef<str>;
+
+    unsafe fn get_object_label(&self, identifier: u32, name: u32) -> String;
+
+    unsafe fn object_ptr_label<S>(&self, ptr: *mut std::ffi::c_void, label: S) where S: AsRef<str>;
+
+    unsafe fn get_object_ptr_label(&self, ptr: *mut std::ffi::c_void) -> String;
 }
 
 pub trait RenderLoop {
@@ -3330,6 +3384,18 @@ pub const VENDOR: u32 = 0x1F00;
 pub const VERSION: u32 = 0x1F02;
 #[allow(non_upper_case_globals)]
 pub const VERTEX_ARRAY: u32 = 0x8074;
+#[allow(non_upper_case_globals)]
+pub const VERTEX_ARRAY_POINTER: u32 = 0x808E;
+#[allow(non_upper_case_globals)]
+pub const NORMAL_ARRAY_POINTER: u32 = 0x808F;
+#[allow(non_upper_case_globals)]
+pub const COLOR_ARRAY_POINTER: u32 = 0x8090;
+#[allow(non_upper_case_globals)]
+pub const INDEX_ARRAY_POINTER: u32 = 0x8091;
+#[allow(non_upper_case_globals)]
+pub const TEXTURE_COORD_ARRAY_POINTER: u32 = 0x8092;
+#[allow(non_upper_case_globals)]
+pub const EDGE_FLAG_ARRAY_POINTER: u32 = 0x8093;
 #[allow(non_upper_case_globals)]
 pub const VERTEX_ARRAY_BINDING: u32 = 0x85B5;
 #[allow(non_upper_case_globals)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,6 @@ pub trait Context {
         + Ord
         + PartialEq
         + PartialOrd;
-    type DebugProc;
 
     unsafe fn create_framebuffer(&self) -> Result<Self::Framebuffer, String>;
 
@@ -700,7 +699,7 @@ pub trait Context {
         source: u32,
         msg_type: u32,
         severity: u32,
-        ids: Option<&[u32]>,
+        ids: &[u32],
         enabled: bool,
     );
 
@@ -714,30 +713,29 @@ pub trait Context {
     ) where
         S: AsRef<str>;
 
-    unsafe fn debug_message_callback(
-        &self,
-        callback: Self::DebugProc,
-        user_data: *mut std::ffi::c_void,
-    );
+    unsafe fn debug_message_callback<F>(&self, callback: F)
+    where
+        F: FnMut(u32, u32, u32, u32, &str);
 
-    unsafe fn get_debug_message_log(
-        &self,
-        count: u32,
-    ) -> Vec<DebugMessageLogEntry>;
+    unsafe fn get_debug_message_log(&self, count: u32) -> Vec<DebugMessageLogEntry>;
 
-    unsafe fn get_pointerv(&self, pname: u32, params: *const *mut std::ffi::c_void);
-
-    unsafe fn push_debug_group<S>(&self, source: u32, id: u32, message: S) where S: AsRef<str>;
+    unsafe fn push_debug_group<S>(&self, source: u32, id: u32, message: S)
+    where
+        S: AsRef<str>;
 
     unsafe fn pop_debug_group(&self);
 
-    unsafe fn object_label<S>(&self, identifier: u32, name: u32, label: S) where S: AsRef<str>;
+    unsafe fn object_label<S>(&self, identifier: u32, name: u32, label: Option<S>)
+    where
+        S: AsRef<str>;
 
     unsafe fn get_object_label(&self, identifier: u32, name: u32) -> String;
 
-    unsafe fn object_ptr_label<S>(&self, ptr: *mut std::ffi::c_void, label: S) where S: AsRef<str>;
+    unsafe fn object_ptr_label<S>(&self, sync: Self::Fence, label: Option<S>)
+    where
+        S: AsRef<str>;
 
-    unsafe fn get_object_ptr_label(&self, ptr: *mut std::ffi::c_void) -> String;
+    unsafe fn get_object_ptr_label(&self, sync: Self::Fence) -> String;
 }
 
 pub trait RenderLoop {
@@ -3384,18 +3382,6 @@ pub const VENDOR: u32 = 0x1F00;
 pub const VERSION: u32 = 0x1F02;
 #[allow(non_upper_case_globals)]
 pub const VERTEX_ARRAY: u32 = 0x8074;
-#[allow(non_upper_case_globals)]
-pub const VERTEX_ARRAY_POINTER: u32 = 0x808E;
-#[allow(non_upper_case_globals)]
-pub const NORMAL_ARRAY_POINTER: u32 = 0x808F;
-#[allow(non_upper_case_globals)]
-pub const COLOR_ARRAY_POINTER: u32 = 0x8090;
-#[allow(non_upper_case_globals)]
-pub const INDEX_ARRAY_POINTER: u32 = 0x8091;
-#[allow(non_upper_case_globals)]
-pub const TEXTURE_COORD_ARRAY_POINTER: u32 = 0x8092;
-#[allow(non_upper_case_globals)]
-pub const EDGE_FLAG_ARRAY_POINTER: u32 = 0x8093;
 #[allow(non_upper_case_globals)]
 pub const VERTEX_ARRAY_BINDING: u32 = 0x85B5;
 #[allow(non_upper_case_globals)]

--- a/src/native.rs
+++ b/src/native.rs
@@ -1641,12 +1641,17 @@ extern "system" fn raw_debug_message_callback<F>(
 where
     F: FnMut(u32, u32, u32, u32, &str)
 {
-    unsafe {
-        let callback: &mut F = &mut *(user_param as *mut _);
-        let slice = std::slice::from_raw_parts(message as *const u8, length as usize);
-        let msg = std::str::from_utf8(slice).unwrap();
-        (callback)(source, gltype, id, severity, msg);
-    }
+    match std::panic::catch_unwind(move || {
+        unsafe {
+            let callback: &mut F = &mut *(user_param as *mut _);
+            let slice = std::slice::from_raw_parts(message as *const u8, length as usize);
+            let msg = std::str::from_utf8(slice).unwrap();
+            (callback)(source, gltype, id, severity, msg);
+        }
+    }) {
+        Ok(_) => (),
+        Err(_) => (),
+    };
 }
 
 pub struct RenderLoop<W> {

--- a/src/web.rs
+++ b/src/web.rs
@@ -2064,10 +2064,6 @@ impl super::Context for Context {
         panic!("WebGL does not support the KHR_debug extension.")
     }
 
-    unsafe fn get_pointerv(&self, _pname: u32, _params: *const *mut std::ffi::c_void) {
-        panic!("WebGL does not support the KHR_debug extension.")
-    }
-
     unsafe fn push_debug_group<S>(
         &self,
         _source: u32,
@@ -2094,7 +2090,7 @@ impl super::Context for Context {
         panic!("WebGL does not support the KHR_debug extension.")
     }
 
-    unsafe fn object_ptr_label<S>(&self, sync: Self::Fence, _label: S) where
+    unsafe fn object_ptr_label<S>(&self, sync: Self::Fence, _label: Option<S>) where
         S: AsRef<str>
     {
         panic!("WebGL does not support the KHR_debug extension.")

--- a/src/web.rs
+++ b/src/web.rs
@@ -97,6 +97,7 @@ impl super::Context for Context {
     type Framebuffer = WebFramebufferKey;
     type Renderbuffer = WebRenderbufferKey;
     type UniformLocation = WebUniformLocationKey;
+    type DebugProc = ();
 
     unsafe fn create_framebuffer(&self) -> Result<Self::Framebuffer, String> {
         let raw_framebuffer = match self.raw {
@@ -2027,6 +2028,83 @@ impl super::Context for Context {
                 pass as u32,
             ),
         }
+    }
+
+    unsafe fn debug_message_control(
+        &self,
+        _source: u32,
+        _msg_type: u32,
+        _severity: u32,
+        _ids: Option<&[u32]>,
+        _enabled: bool,
+    ) {
+        panic!("WebGL does not support the KHR_debug extension.")
+    }
+
+    unsafe fn debug_message_insert<S>(
+        &self,
+        _source: u32,
+        _msg_type: u32,
+        _id: u32,
+        _severity: u32,
+        _msg: S,
+    ) where
+        S: AsRef<str>
+    {
+        panic!("WebGL does not support the KHR_debug extension.")
+    }
+
+    unsafe fn debug_message_callback(
+        &self,
+        _callback: Self::DebugProc,
+        _user_data: *mut std::ffi::c_void,
+    ) {
+        panic!("WebGL does not support the KHR_debug extension.")
+    }
+
+    unsafe fn get_debug_message_log(&self, _count: u32) -> Vec<DebugMessageLogEntry> {
+        panic!("WebGL does not support the KHR_debug extension.")
+    }
+
+    unsafe fn get_pointerv(&self, _pname: u32, _params: *const *mut std::ffi::c_void) {
+        panic!("WebGL does not support the KHR_debug extension.")
+    }
+
+    unsafe fn push_debug_group<S>(
+        &self,
+        _source: u32,
+        _id: u32,
+        _message: S
+    ) where
+        S: AsRef<str>
+    {
+        panic!("WebGL does not support the KHR_debug extension.")
+    }
+
+    unsafe fn pop_debug_group(&self) {
+        panic!("WebGL does not support the KHR_debug extension.")
+    }
+
+    unsafe fn object_label<S>(&self, _identifier: u32, _name: u32, _label: S) where S: AsRef<str> {
+        panic!("WebGL does not support the KHR_debug extension.")
+    }
+
+    unsafe fn get_object_label(&self, _identifier: u32, _name: u32) -> String {
+        panic!("WebGL does not support the KHR_debug extension.")
+    }
+
+    unsafe fn object_ptr_label<S>(
+        &self,
+        _ptr: *mut std::ffi::c_void,
+        _label: S
+    ) where
+        S: AsRef<str>
+    {
+        panic!("WebGL does not support the KHR_debug extension.")
+    }
+
+    unsafe fn get_object_ptr_label(&self, _ptr: *mut std::ffi::c_void) -> String {
+        panic!("WebGL does not support the KHR_debug extension.")
     }
 }
 

--- a/src/web.rs
+++ b/src/web.rs
@@ -97,7 +97,6 @@ impl super::Context for Context {
     type Framebuffer = WebFramebufferKey;
     type Renderbuffer = WebRenderbufferKey;
     type UniformLocation = WebUniformLocationKey;
-    type DebugProc = ();
 
     unsafe fn create_framebuffer(&self) -> Result<Self::Framebuffer, String> {
         let raw_framebuffer = match self.raw {
@@ -2035,7 +2034,7 @@ impl super::Context for Context {
         _source: u32,
         _msg_type: u32,
         _severity: u32,
-        _ids: Option<&[u32]>,
+        _ids: &[u32],
         _enabled: bool,
     ) {
         panic!("WebGL does not support the KHR_debug extension.")
@@ -2054,11 +2053,10 @@ impl super::Context for Context {
         panic!("WebGL does not support the KHR_debug extension.")
     }
 
-    unsafe fn debug_message_callback(
-        &self,
-        _callback: Self::DebugProc,
-        _user_data: *mut std::ffi::c_void,
-    ) {
+    unsafe fn debug_message_callback<F>(&self, _callback: F)
+    where
+        F: FnMut(u32, u32, u32, u32, &str)
+    {
         panic!("WebGL does not support the KHR_debug extension.")
     }
 
@@ -2085,7 +2083,10 @@ impl super::Context for Context {
         panic!("WebGL does not support the KHR_debug extension.")
     }
 
-    unsafe fn object_label<S>(&self, _identifier: u32, _name: u32, _label: S) where S: AsRef<str> {
+    unsafe fn object_label<S>(&self, _identifier: u32, _name: u32, _label: Option<S>)
+    where
+        S: AsRef<str>
+    {
         panic!("WebGL does not support the KHR_debug extension.")
     }
 
@@ -2093,17 +2094,13 @@ impl super::Context for Context {
         panic!("WebGL does not support the KHR_debug extension.")
     }
 
-    unsafe fn object_ptr_label<S>(
-        &self,
-        _ptr: *mut std::ffi::c_void,
-        _label: S
-    ) where
+    unsafe fn object_ptr_label<S>(&self, sync: Self::Fence, _label: S) where
         S: AsRef<str>
     {
         panic!("WebGL does not support the KHR_debug extension.")
     }
 
-    unsafe fn get_object_ptr_label(&self, _ptr: *mut std::ffi::c_void) -> String {
+    unsafe fn get_object_ptr_label(&self, sync: Self::Fence) -> String {
         panic!("WebGL does not support the KHR_debug extension.")
     }
 }


### PR DESCRIPTION
Fixes #19.

A WebGL context will `panic!()` if these functions are called with a message indicating it does not support the `KHR_debug` extension.