### PR TITLE
Change native get_uniform_location to return None if not found

### DIFF
--- a/src/native.rs
+++ b/src/native.rs
@@ -804,7 +804,12 @@ impl super::Context for Context {
     ) -> Option<Self::UniformLocation> {
         let gl = &self.raw;
         let name = CString::new(name).unwrap();
-        Some(gl.GetUniformLocation(program, name.as_ptr() as *const i8) as u32)
+        let uniform_location = gl.GetUniformLocation(program, name.as_ptr() as *const i8);
+        if uniform_location < 0 {
+            None
+        } else {
+            Some(uniform_location as u32)
+        }
     }
 
     unsafe fn get_attrib_location(&self, program: Self::Program, name: &str) -> i32 {


### PR DESCRIPTION
This should match the behavior of web get_uniform_location, I think?

I'm not sure whether this is a symptom of another gfx-backend-gl problem or not, but I needed to check if this returns None to fix a panic in the gl backend on wasm32, and the behavior of the native version didn't match.  This will potentially "break" gfx-backend-gl, but I think it's just exposing an existing bug.