### PR TITLE
Add `bind_attrib_location`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,6 +402,8 @@ pub trait Context {
 
     unsafe fn get_attrib_location(&self, program: Self::Program, name: &str) -> i32;
 
+    unsafe fn bind_attrib_location(&self, program: Self::Program, index: u32, name: &str);
+
     unsafe fn get_sync_status(&self, fence: Self::Fence) -> u32;
 
     unsafe fn is_sync(&self, fence: Self::Fence) -> bool;

--- a/src/native.rs
+++ b/src/native.rs
@@ -832,6 +832,12 @@ impl super::Context for Context {
         gl.GetAttribLocation(program, name.as_ptr() as *const i8) as i32
     }
 
+    unsafe fn bind_attrib_location(&self, program: Self::Program, index: u32, name: &str) {
+        let gl = &self.raw;
+        let name = CString::new(name).unwrap();
+        gl.BindAttribLocation(program, index, name.as_ptr() as *const i8);
+    }
+
     unsafe fn get_sync_status(&self, fence: Self::Fence) -> u32 {
         let gl = &self.raw;
         let mut len = 0;

--- a/src/web.rs
+++ b/src/web.rs
@@ -1133,6 +1133,15 @@ impl super::Context for Context {
         }
     }
 
+    unsafe fn bind_attrib_location(&self, program: Self::Program, index: u32, name: &str) {
+        let programs = self.programs.borrow();
+        let raw_program = programs.1.get_unchecked(program);
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => gl.bind_attrib_location(raw_program, index, name),
+            RawRenderingContext::WebGl2(ref gl) => gl.bind_attrib_location(raw_program, index, name),
+        }
+    }
+
     unsafe fn get_sync_status(&self, fence: Self::Fence) -> u32 {
         let fences = self.fences.borrow();
         let raw_fence = fences.1.get_unchecked(fence);


### PR DESCRIPTION
There was a grand total of one function missing from glow when I ported Tetra, so the API coverage is looking pretty good, at least for 2D stuff! 

Not touched WASM code before, but I was able to make a guess at the WebGL implementation based on the surrounding code - let me know if it's horribly broken :)