### PR TITLE
Move `MAX_LABEL_LENGTH` constant behind debug extension

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glow"
-version = "0.2.2"
+version = "0.2.3"
 description = "GL on Whatever: a set of bindings to run GL anywhere (Open GL, OpenGL ES, and WebGL) and avoid target-specific code."
 authors = ["Joshua Groves <josh@joshgroves.com>"]
 homepage = "https://github.com/grovesNL/glow.git"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,8 @@ pub trait Context {
         + PartialEq
         + PartialOrd;
 
+    fn supports_debug(&self) -> bool;
+
     unsafe fn create_framebuffer(&self) -> Result<Self::Framebuffer, String>;
 
     unsafe fn create_renderbuffer(&self) -> Result<Self::Renderbuffer, String>;

--- a/src/native.rs
+++ b/src/native.rs
@@ -45,7 +45,7 @@ impl Context {
 
         // After the extensions are known, we can populate constants (including
         // constants that depend on extensions being enabled)
-        context.constants.max_label_length = if context.extensions.contains("GL_KHR_debug") {
+        context.constants.max_label_length = if context.supports_debug() {
             unsafe { context.get_parameter_i32(MAX_LABEL_LENGTH) }
         } else {
             0
@@ -73,6 +73,10 @@ impl super::Context for Context {
     type Framebuffer = native_gl::types::GLuint;
     type Renderbuffer = native_gl::types::GLuint;
     type UniformLocation = native_gl::types::GLuint;
+
+    fn supports_debug(&self) -> bool {
+        self.extensions.contains("GL_KHR_debug")
+    }
 
     unsafe fn create_framebuffer(&self) -> Result<Self::Framebuffer, String> {
         let gl = &self.raw;

--- a/src/web.rs
+++ b/src/web.rs
@@ -98,6 +98,10 @@ impl super::Context for Context {
     type Renderbuffer = WebRenderbufferKey;
     type UniformLocation = WebUniformLocationKey;
 
+    fn supports_debug(&self) -> bool {
+        false
+    }
+
     unsafe fn create_framebuffer(&self) -> Result<Self::Framebuffer, String> {
         let raw_framebuffer = match self.raw {
             RawRenderingContext::WebGl1(ref gl) => gl.create_framebuffer(),


### PR DESCRIPTION
Fix a subtle issue in which we might trigger an invalid enum value error. Later if code checks `get_error` somewhere, then we might panic at the wrong place (like checking `VENDOR` in the case of gfx quad).