### PR TITLE
Ease version requirements of wasm_bindgen crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ glutin = { version = "0.22.0-alpha3", optional = true }
 sdl2 = { version = "0.32", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-js-sys = { version = "0.3", optional = true }
-wasm-bindgen = { version = "0.2", optional = true }
+js-sys = { version = "~0.3", optional = true }
+wasm-bindgen = { version = "~0.2", optional = true }
 webgl_stdweb = { version = "0.3", optional = true }
 slotmap = "0.3"
 
@@ -34,7 +34,7 @@ package = "stdweb"
 optional = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web_sys]
-version = "0.3.23"
+version = "~0.3.23"
 package = "web-sys"
 optional = true
 features = [


### PR DESCRIPTION
This patch allows glow to be used with more recent version of wasm-bindgen.