### PR TITLE
Remove unnecessary mutability from i32 uniform setters.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -461,13 +461,13 @@ pub trait HasContext {
         w: i32,
     );
 
-    unsafe fn uniform_1_i32_slice(&self, location: Option<Self::UniformLocation>, v: &mut [i32; 1]);
+    unsafe fn uniform_1_i32_slice(&self, location: Option<Self::UniformLocation>, v: &[i32; 1]);
 
-    unsafe fn uniform_2_i32_slice(&self, location: Option<Self::UniformLocation>, v: &mut [i32; 2]);
+    unsafe fn uniform_2_i32_slice(&self, location: Option<Self::UniformLocation>, v: &[i32; 2]);
 
-    unsafe fn uniform_3_i32_slice(&self, location: Option<Self::UniformLocation>, v: &mut [i32; 3]);
+    unsafe fn uniform_3_i32_slice(&self, location: Option<Self::UniformLocation>, v: &[i32; 3]);
 
-    unsafe fn uniform_4_i32_slice(&self, location: Option<Self::UniformLocation>, v: &mut [i32; 4]);
+    unsafe fn uniform_4_i32_slice(&self, location: Option<Self::UniformLocation>, v: &[i32; 4]);
 
     unsafe fn uniform_1_f32(&self, location: Option<Self::UniformLocation>, x: f32);
 

--- a/src/native.rs
+++ b/src/native.rs
@@ -1074,7 +1074,7 @@ impl HasContext for Context {
     unsafe fn uniform_1_i32_slice(
         &self,
         location: Option<Self::UniformLocation>,
-        v: &mut [i32; 1],
+        v: &[i32; 1],
     ) {
         let gl = &self.raw;
         gl.Uniform1iv(location.unwrap_or(0) as i32, 1, v.as_ptr());
@@ -1083,7 +1083,7 @@ impl HasContext for Context {
     unsafe fn uniform_2_i32_slice(
         &self,
         location: Option<Self::UniformLocation>,
-        v: &mut [i32; 2],
+        v: &[i32; 2],
     ) {
         let gl = &self.raw;
         gl.Uniform2iv(location.unwrap_or(0) as i32, 1, v.as_ptr());
@@ -1092,7 +1092,7 @@ impl HasContext for Context {
     unsafe fn uniform_3_i32_slice(
         &self,
         location: Option<Self::UniformLocation>,
-        v: &mut [i32; 3],
+        v: &[i32; 3],
     ) {
         let gl = &self.raw;
         gl.Uniform3iv(location.unwrap_or(0) as i32, 1, v.as_ptr());
@@ -1101,7 +1101,7 @@ impl HasContext for Context {
     unsafe fn uniform_4_i32_slice(
         &self,
         location: Option<Self::UniformLocation>,
-        v: &mut [i32; 4],
+        v: &[i32; 4],
     ) {
         let gl = &self.raw;
         gl.Uniform4iv(location.unwrap_or(0) as i32, 1, v.as_ptr());

--- a/src/stdweb.rs
+++ b/src/stdweb.rs
@@ -1425,7 +1425,7 @@ impl HasContext for Context {
     unsafe fn uniform_1_i32_slice(
         &self,
         uniform_location: Option<Self::UniformLocation>,
-        v: &mut [i32; 1],
+        v: &[i32; 1],
     ) {
         let uniform_locations = self.uniform_locations.borrow();
         let raw_uniform_location = uniform_location.map(|u| uniform_locations.1.get_unchecked(u));
@@ -1442,7 +1442,7 @@ impl HasContext for Context {
     unsafe fn uniform_2_i32_slice(
         &self,
         uniform_location: Option<Self::UniformLocation>,
-        v: &mut [i32; 2],
+        v: &[i32; 2],
     ) {
         let uniform_locations = self.uniform_locations.borrow();
         let raw_uniform_location = uniform_location.map(|u| uniform_locations.1.get_unchecked(u));
@@ -1459,7 +1459,7 @@ impl HasContext for Context {
     unsafe fn uniform_3_i32_slice(
         &self,
         uniform_location: Option<Self::UniformLocation>,
-        v: &mut [i32; 3],
+        v: &[i32; 3],
     ) {
         let uniform_locations = self.uniform_locations.borrow();
         let raw_uniform_location = uniform_location.map(|u| uniform_locations.1.get_unchecked(u));
@@ -1476,7 +1476,7 @@ impl HasContext for Context {
     unsafe fn uniform_4_i32_slice(
         &self,
         uniform_location: Option<Self::UniformLocation>,
-        v: &mut [i32; 4],
+        v: &[i32; 4],
     ) {
         let uniform_locations = self.uniform_locations.borrow();
         let raw_uniform_location = uniform_location.map(|u| uniform_locations.1.get_unchecked(u));

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -1442,7 +1442,7 @@ impl HasContext for Context {
     unsafe fn uniform_1_i32_slice(
         &self,
         uniform_location: Option<Self::UniformLocation>,
-        v: &mut [i32; 1],
+        v: &[i32; 1],
     ) {
         let uniform_locations = self.uniform_locations.borrow();
         let raw_uniform_location = uniform_location.map(|u| uniform_locations.1.get_unchecked(u));
@@ -1459,7 +1459,7 @@ impl HasContext for Context {
     unsafe fn uniform_2_i32_slice(
         &self,
         uniform_location: Option<Self::UniformLocation>,
-        v: &mut [i32; 2],
+        v: &[i32; 2],
     ) {
         let uniform_locations = self.uniform_locations.borrow();
         let raw_uniform_location = uniform_location.map(|u| uniform_locations.1.get_unchecked(u));
@@ -1476,7 +1476,7 @@ impl HasContext for Context {
     unsafe fn uniform_3_i32_slice(
         &self,
         uniform_location: Option<Self::UniformLocation>,
-        v: &mut [i32; 3],
+        v: &[i32; 3],
     ) {
         let uniform_locations = self.uniform_locations.borrow();
         let raw_uniform_location = uniform_location.map(|u| uniform_locations.1.get_unchecked(u));
@@ -1493,7 +1493,7 @@ impl HasContext for Context {
     unsafe fn uniform_4_i32_slice(
         &self,
         uniform_location: Option<Self::UniformLocation>,
-        v: &mut [i32; 4],
+        v: &[i32; 4],
     ) {
         let uniform_locations = self.uniform_locations.borrow();
         let raw_uniform_location = uniform_location.map(|u| uniform_locations.1.get_unchecked(u));


### PR DESCRIPTION
Uniform setters for i32 slices had an unnecessary mutability requirement on the data.