### PR TITLE
Add GL enums for Luminance and Luminance + Alpha

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1848,6 +1848,10 @@ pub const LOW_FLOAT: u32 = 0x8DF0;
 
 pub const LOW_INT: u32 = 0x8DF3;
 
+pub const LUMINANCE : u32 = 0x1909;
+
+pub const LUMINANCE_ALPHA : u32 = 0x190A;
+
 pub const MAJOR_VERSION: u32 = 0x821B;
 
 pub const MANUAL_GENERATE_MIPMAP: u32 = 0x8294;


### PR DESCRIPTION
These enums are allowed in WebGL as mentioned here: https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texImage2D

The values themselves I've taken from here: https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14

There's maybe a bigger question of adding all the legacy enums but it's not clear to me which versions of OpenGL this lib should be targeting so I have only added the ones explicitly allowed in WebGL.

