### PR TITLE
Make get_attrib_location() return Option<u32>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,7 +365,7 @@ pub trait HasContext {
         name: &str,
     ) -> Option<Self::UniformLocation>;
 
-    unsafe fn get_attrib_location(&self, program: Self::Program, name: &str) -> i32;
+    unsafe fn get_attrib_location(&self, program: Self::Program, name: &str) -> Option<u32>;
 
     unsafe fn bind_attrib_location(&self, program: Self::Program, index: u32, name: &str);
 

--- a/src/native.rs
+++ b/src/native.rs
@@ -854,10 +854,15 @@ impl HasContext for Context {
         }
     }
 
-    unsafe fn get_attrib_location(&self, program: Self::Program, name: &str) -> i32 {
+    unsafe fn get_attrib_location(&self, program: Self::Program, name: &str) -> Option<u32> {
         let gl = &self.raw;
         let name = CString::new(name).unwrap();
-        gl.GetAttribLocation(program, name.as_ptr() as *const native_gl::types::GLchar) as i32
+        let attrib_location = gl.GetAttribLocation(program, name.as_ptr() as *const native_gl::types::GLchar);
+        if attrib_location < 0 {
+            None
+        } else {
+            Some(attrib_location as u32)
+        }
     }
 
     unsafe fn bind_attrib_location(&self, program: Self::Program, index: u32, name: &str) {

--- a/src/stdweb.rs
+++ b/src/stdweb.rs
@@ -1282,12 +1282,17 @@ impl HasContext for Context {
         }
     }
 
-    unsafe fn get_attrib_location(&self, program: Self::Program, name: &str) -> i32 {
+    unsafe fn get_attrib_location(&self, program: Self::Program, name: &str) -> Option<u32> {
         let programs = self.programs.borrow();
         let raw_program = programs.1.get_unchecked(program);
-        match self.raw {
+        let attrib_location = match self.raw {
             RawRenderingContext::WebGL1(ref gl) => gl.get_attrib_location(raw_program, name),
             RawRenderingContext::WebGL2(ref gl) => gl.get_attrib_location(raw_program, name),
+        };
+        if attrib_location < 0 {
+            None
+        } else {
+            Some(attrib_location as u32)
         }
     }
 

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -1255,12 +1255,17 @@ impl HasContext for Context {
         }
     }
 
-    unsafe fn get_attrib_location(&self, program: Self::Program, name: &str) -> i32 {
+    unsafe fn get_attrib_location(&self, program: Self::Program, name: &str) -> Option<u32> {
         let programs = self.programs.borrow();
         let raw_program = programs.1.get_unchecked(program);
-        match self.raw {
+        let attrib_location = match self.raw {
             RawRenderingContext::WebGl1(ref gl) => gl.get_attrib_location(raw_program, name),
             RawRenderingContext::WebGl2(ref gl) => gl.get_attrib_location(raw_program, name),
+        };
+        if attrib_location < 0 {
+            None
+        } else {
+            Some(attrib_location as u32)
         }
     }
 


### PR DESCRIPTION
...Instead of just returning an i32 with negative numbers
being an error.  Resolves issue #54.

glGetAttribLocation only has one possible error value as of
OpenGL 4, so returning Option rather than Result is fine.

Builds but not tested in practice on all platforms yet.