### PR TITLE
Removed tracking for Self::UniformLocation.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ pub trait HasContext {
     type Fence: Copy + Clone + Debug + Eq + Hash + Ord + PartialEq + PartialOrd;
     type Framebuffer: Copy + Clone + Debug + Eq + Hash + Ord + PartialEq + PartialOrd;
     type Renderbuffer: Copy + Clone + Debug + Eq + Hash + Ord + PartialEq + PartialOrd;
-    type UniformLocation: Copy + Clone + Debug + Eq + Hash + Ord + PartialEq + PartialOrd;
+    type UniformLocation: Clone + Debug;
 
     fn supports_debug(&self) -> bool;
 


### PR DESCRIPTION
The tracking of Self::UniformLocation was causing a memory leak on web backends, as that resource is not freed with a `destroy_*` function.

Self::UniformLocation is now WebGlUniformLocation for the web backends.

Also constraints of the associated type HasContext::UniformLocation have been relaxed as it seems that they are no longer needed, and WebGlUniformLocation doesn't implement those.

Fixes #59 