### PR TITLE
Instructions for the stdweb backend in the hello example.

### DIFF
--- a/examples/hello/README.md
+++ b/examples/hello/README.md
@@ -18,9 +18,17 @@ cargo run --features=window-sdl2
 
 `cd` to `examples/hello` directory
 
+To run with web-sys:
+
 ```shell
 cargo +nightly build --target wasm32-unknown-unknown
 mkdir -p generated
 wasm-bindgen ../../target/wasm32-unknown-unknown/debug/hello.wasm --out-dir generated --no-modules
 cp index.html generated
+```
+
+To run with stdweb:
+
+```shell
+cargo web start --no-default-features --features stdweb --target wasm32-unknown-unknown
 ```


### PR DESCRIPTION
Previously there weren't instructions to run the 'hello' example on stdweb, so I'm adding them.

But I also noticed that the README.md is not quite right yet. The web-sys backend instructions seem obsolete, but I can't find and easy way to make it work with wasm-pack because 'hello' is a binary crate.

Here is a pull request to make wasm-pack compatible with binary crates: https://github.com/rustwasm/wasm-pack/pull/736