### PR TITLE
add support for texture 2d with Html Image element for web_sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ features = [
   "Document",
   "Element",
   "HtmlCanvasElement",
+  "HtmlImageElement",
   "WebGlActiveInfo",
   "WebGlBuffer",
   "WebGlFramebuffer",

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -7,7 +7,7 @@ use wasm_bindgen::prelude::*;
 use web_sys::{
     WebGl2RenderingContext, WebGlBuffer, WebGlFramebuffer, WebGlProgram, WebGlRenderbuffer,
     WebGlRenderingContext, WebGlSampler, WebGlShader, WebGlSync, WebGlTexture,
-    WebGlUniformLocation, WebGlVertexArrayObject,
+    WebGlUniformLocation, WebGlVertexArrayObject, HtmlImageElement,
 };
 
 #[derive(Debug)]
@@ -177,6 +177,44 @@ impl Context {
             renderbuffers: tracked_resource(),
         }
     }
+
+    pub unsafe fn tex_image_2d_with_html_image(
+        &self,
+        target: u32,
+        level: i32,
+        internal_format: i32,
+        format: u32,
+        ty: u32,
+        image: &HtmlImageElement,
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => {
+                // TODO: Handle return value?
+                gl.tex_image_2d_with_u32_and_u32_and_image(
+                    target,
+                    level,
+                    internal_format,
+                    format,
+                    ty,
+                    image,
+                )
+                .unwrap();
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                // TODO: Handle return value?
+                gl.tex_image_2d_with_u32_and_u32_and_html_image_element(
+                    target,
+                    level,
+                    internal_format,
+                    format,
+                    ty,
+                    image,
+                )
+                .unwrap();
+            }
+        }
+    }
+
 }
 
 new_key_type! { pub struct WebShaderKey; }


### PR DESCRIPTION
Related to #21. For web target, it is usual to let the Html element do the loading and decoding, then passing it to webgl.

This PR only affects the web-sys backend. For some reason, I wasn't able to find the equivalent in stdweb...

There is also some methods for canvas and image_3d, however I am unsure if they're used as often as this version.