### PR TITLE
Update to glutin 0.22.0-alpha5, redraw requested events. Fixes #70

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ web-sys = ["web_sys", "js-sys", "wasm-bindgen"]
 stdweb = ["std_web", "webgl_stdweb"]
 
 [target.'cfg(not(any(target_arch = "wasm32")))'.dependencies]
-glutin = { version = "0.22.0-alpha3", optional = true }
+glutin = { version = "0.22.0-alpha5", optional = true }
 sdl2 = { version = "0.32", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ web-sys = ["web_sys", "js-sys", "wasm-bindgen"]
 stdweb = ["std_web", "webgl_stdweb"]
 
 [target.'cfg(not(any(target_arch = "wasm32")))'.dependencies]
-glutin = { version = "0.22.0-alpha5", optional = true }
+glutin = { version = "=0.22.0-alpha5", optional = true }
 sdl2 = { version = "0.32", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/examples/hello/Cargo.toml
+++ b/examples/hello/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 glow = { path = "../../", default-features=false }
 
 [target.'cfg(not(any(target_arch = "wasm32")))'.dependencies]
-glutin = { version = "0.22.0-alpha3", optional = true }
+glutin = { version = "0.22.0-alpha5", optional = true }
 sdl2 = { version = "0.32", optional = true }
 
 [features]

--- a/examples/hello/Cargo.toml
+++ b/examples/hello/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 glow = { path = "../../", default-features=false }
 
 [target.'cfg(not(any(target_arch = "wasm32")))'.dependencies]
-glutin = { version = "0.22.0-alpha5", optional = true }
+glutin = { version = "=0.22.0-alpha5", optional = true }
 sdl2 = { version = "0.32", optional = true }
 
 [features]

--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -185,21 +185,21 @@ fn main() {
                         println!("Event::LoopDestroyed!");
                         return;
                     }
-                    Event::EventsCleared => {
-                        println!("EventsCleared");
+                    Event::MainEventsCleared => {
+                        println!("MainEventsCleared");
                         windowed_context.window().request_redraw();
+                    }
+                    Event::RedrawRequested(_window_id) => {
+                        println!("Event::RedrawRequested");
+                        gl.clear(glow::COLOR_BUFFER_BIT);
+                        gl.draw_arrays(glow::TRIANGLES, 0, 3);
+                        windowed_context.swap_buffers().unwrap();
                     }
                     Event::WindowEvent { ref event, .. } => match event {
                         WindowEvent::Resized(logical_size) => {
                             println!("WindowEvent::Resized: {:?}", logical_size);
                             let dpi_factor = windowed_context.window().hidpi_factor();
                             windowed_context.resize(logical_size.to_physical(dpi_factor));
-                        }
-                        WindowEvent::RedrawRequested => {
-                            println!("WindowEvent::RedrawRequested");
-                            gl.clear(glow::COLOR_BUFFER_BIT);
-                            gl.draw_arrays(glow::TRIANGLES, 0, 3);
-                            windowed_context.swap_buffers().unwrap();
                         }
                         WindowEvent::CloseRequested => {
                             println!("WindowEvent::CloseRequested");


### PR DESCRIPTION
Fixes #70 glow/examples/hello fails to compile for window-glutin: error[E0599]: no variant or associated item named `EventsCleared`