### PR TITLE
Add glReadBuffer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -773,6 +773,8 @@ pub trait HasContext {
 
     unsafe fn shader_storage_block_binding(&self, program: Self::Program, index: u32, binding: u32);
 
+    unsafe fn read_buffer(&self, src: u32);
+
     unsafe fn read_pixels(&self, x: i32, y: i32, width: i32, height: i32, format: u32, gltype: u32, data: &mut [u8]);
 }
 

--- a/src/native.rs
+++ b/src/native.rs
@@ -1879,6 +1879,11 @@ impl HasContext for Context {
         gl.ShaderStorageBlockBinding(program, index, binding);
     }
 
+    unsafe fn read_buffer(&self, src: u32) {
+        let gl = &self.raw;
+        gl.ReadBuffer(src);
+    }
+
     unsafe fn read_pixels(
         &self,
         x: i32,

--- a/src/stdweb.rs
+++ b/src/stdweb.rs
@@ -2412,6 +2412,13 @@ impl HasContext for Context {
         panic!("Shader Storage Buffers are not supported by webgl")
     }
 
+    unsafe fn read_buffer(&self, src: u32) {
+        match self.raw {
+            RawRenderingContext::WebGl1(..) => panic!("read_buffer is not supported by WebGL1"),
+            RawRenderingContext::WebGl2(ref gl) => gl.read_buffer(src),
+        }
+    }
+
     unsafe fn read_pixels(
         &self,
         x: i32,

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -2527,6 +2527,13 @@ impl HasContext for Context {
         panic!("Shader Storage Buffers are not supported by webgl")
     }
 
+    unsafe fn read_buffer(&self, src: u32) {
+        match self.raw {
+            RawRenderingContext::WebGl1(..) => panic!("read_buffer is not supported by WebGL1"),
+            RawRenderingContext::WebGl2(ref gl) => gl.read_buffer(src),
+        }
+    }
+
     unsafe fn read_pixels(
         &self,
         x: i32,


### PR DESCRIPTION
Bridges the glReadBuffer() function supported by WebGL 2.0 and OpenGL 2.0+:

https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glReadBuffer.xhtml
https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.4
https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glReadBuffer.xhtml

Not extensively tested, but at least the example compiles (for glutin, sdl, web-sys, and stdweb)