### PR TITLE
ADDED: is_enabled variants added for glIsEnabled and IsEnabled

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,6 +297,8 @@ pub trait HasContext {
 
     unsafe fn enable(&self, parameter: u32);
 
+    unsafe fn is_enabled(&self, parameter: u32) -> bool;
+
     unsafe fn enable_draw_buffer(&self, parameter: u32, draw_buffer: u32);
 
     unsafe fn enable_vertex_attrib_array(&self, index: u32);

--- a/src/native.rs
+++ b/src/native.rs
@@ -704,6 +704,11 @@ impl HasContext for Context {
         gl.Enable(parameter);
     }
 
+    unsafe fn is_enabled(&self, parameter: u32) -> bool {
+        let gl = &self.raw;
+        gl.IsEnabled(parameter) != 0
+    }
+
     unsafe fn enable_draw_buffer(&self, parameter: u32, draw_buffer: u32) {
         let gl = &self.raw;
         gl.Enablei(parameter, draw_buffer);

--- a/src/stdweb.rs
+++ b/src/stdweb.rs
@@ -1091,6 +1091,13 @@ impl HasContext for Context {
         }
     }
 
+    unsafe fn is_enabled(&self, parameter: u32) -> bool  {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => gl.is_enabled(parameter),
+            RawRenderingContext::WebGl2(ref gl) => gl.is_enabled(parameter),
+        }
+    }
+
     unsafe fn enable_draw_buffer(&self, _parameter: u32, _draw_buffer: u32) {
         panic!("Draw buffer enable is not supported");
     }

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -1193,6 +1193,13 @@ impl HasContext for Context {
         }
     }
 
+    unsafe fn is_enabled(&self, parameter: u32) -> bool  {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => gl.is_enabled(parameter),
+            RawRenderingContext::WebGl2(ref gl) => gl.is_enabled(parameter),
+        }
+    }
+
     unsafe fn enable_draw_buffer(&self, _parameter: u32, _draw_buffer: u32) {
         panic!("Draw buffer enable is not supported");
     }


### PR DESCRIPTION
Both these functions exist for GL and WebGL across all versions; I assume their exemption was an oversight. 

This is a very useful set of functions for tracking or checking state across "passes", depending on some cases where a user cannot track a full state object around.