### PR TITLE
Add web::Context::tex_image_2d_with_image_bitmap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ features = [
   "Element",
   "HtmlCanvasElement",
   "HtmlImageElement",
+  "ImageBitmap",
   "WebGlActiveInfo",
   "WebGlBuffer",
   "WebGlFramebuffer",

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -5,9 +5,9 @@ use slotmap::{new_key_type, SecondaryMap, SlotMap};
 use std::cell::RefCell;
 use wasm_bindgen::prelude::*;
 use web_sys::{
-    HtmlImageElement, WebGl2RenderingContext, WebGlBuffer, WebGlFramebuffer, WebGlProgram,
-    WebGlRenderbuffer, WebGlRenderingContext, WebGlSampler, WebGlShader, WebGlSync, WebGlTexture,
-    WebGlUniformLocation, WebGlVertexArrayObject,
+    HtmlImageElement, ImageBitmap, WebGl2RenderingContext, WebGlBuffer, WebGlFramebuffer,
+    WebGlProgram, WebGlRenderbuffer, WebGlRenderingContext, WebGlSampler, WebGlShader, WebGlSync,
+    WebGlTexture, WebGlUniformLocation, WebGlVertexArrayObject,
 };
 
 #[derive(Debug)]
@@ -301,6 +301,43 @@ impl Context {
                     format,
                     ty,
                     image,
+                )
+                .unwrap();
+            }
+        }
+    }
+
+    pub unsafe fn tex_image_2d_with_image_bitmap(
+        &self,
+        target: u32,
+        level: i32,
+        internal_format: i32,
+        format: u32,
+        ty: u32,
+        pixels: &ImageBitmap,
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => {
+                // TODO: Handle return value?
+                gl.tex_image_2d_with_u32_and_u32_and_image_bitmap(
+                    target,
+                    level,
+                    internal_format,
+                    format,
+                    ty,
+                    pixels,
+                )
+                .unwrap();
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                // TODO: Handle return value?
+                gl.tex_image_2d_with_u32_and_u32_and_image_bitmap(
+                    target,
+                    level,
+                    internal_format,
+                    format,
+                    ty,
+                    pixels,
                 )
                 .unwrap();
             }


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texImage2D

https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.WebGlRenderingContext.html#method.tex_image_2d_with_u32_and_u32_and_image_bitmap

Using the `ImageBitmap` object, we can let the browser do the image decoding stuff, which avoid embeding crates like [png](https://crates.io/crates/png) into the wasm file.