### PR TITLE
Add _sized_slice() for glUniform*fv calls

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -499,6 +499,14 @@ pub trait HasContext {
 
     unsafe fn uniform_4_i32_slice(&self, location: Option<&Self::UniformLocation>, v: &[i32]);
 
+    unsafe fn uniform_1_i32_sized_slice(&self, location: Option<&Self::UniformLocation>, v: &[i32; 1]);
+
+    unsafe fn uniform_2_i32_sized_slice(&self, location: Option<&Self::UniformLocation>, v: &[i32; 2]);
+
+    unsafe fn uniform_3_i32_sized_slice(&self, location: Option<&Self::UniformLocation>, v: &[i32; 3]);
+
+    unsafe fn uniform_4_i32_sized_slice(&self, location: Option<&Self::UniformLocation>, v: &[i32; 4]);
+
     unsafe fn uniform_1_f32(&self, location: Option<&Self::UniformLocation>, x: f32);
 
     unsafe fn uniform_2_f32(&self, location: Option<&Self::UniformLocation>, x: f32, y: f32);
@@ -522,6 +530,14 @@ pub trait HasContext {
 
     unsafe fn uniform_4_f32_slice(&self, location: Option<&Self::UniformLocation>, v: &[f32]);
 
+    unsafe fn uniform_1_f32_sized_slice(&self, location: Option<&Self::UniformLocation>, v: &[f32; 1]);
+
+    unsafe fn uniform_2_f32_sized_slice(&self, location: Option<&Self::UniformLocation>, v: &[f32; 2]);
+
+    unsafe fn uniform_3_f32_sized_slice(&self, location: Option<&Self::UniformLocation>, v: &[f32; 3]);
+
+    unsafe fn uniform_4_f32_sized_slice(&self, location: Option<&Self::UniformLocation>, v: &[f32; 4]);
+
     unsafe fn uniform_matrix_2_f32_slice(
         &self,
         location: Option<&Self::UniformLocation>,
@@ -541,6 +557,27 @@ pub trait HasContext {
         location: Option<&Self::UniformLocation>,
         transpose: bool,
         v: &[f32],
+    );
+
+    unsafe fn uniform_matrix_2_f32_sized_slice(
+        &self,
+        location: Option<&Self::UniformLocation>,
+        transpose: bool,
+        v: &[f32; 4],
+    );
+
+    unsafe fn uniform_matrix_3_f32_sized_slice(
+        &self,
+        location: Option<&Self::UniformLocation>,
+        transpose: bool,
+        v: &[f32; 9],
+    );
+
+    unsafe fn uniform_matrix_4_f32_sized_slice(
+        &self,
+        location: Option<&Self::UniformLocation>,
+        transpose: bool,
+        v: &[f32; 16],
     );
 
     unsafe fn unmap_buffer(&self, target: u32);

--- a/src/native.rs
+++ b/src/native.rs
@@ -1153,6 +1153,42 @@ impl HasContext for Context {
         gl.Uniform4iv(*location.unwrap_or(&0) as i32, v.len() as i32 / 4, v.as_ptr());
     }
 
+    unsafe fn uniform_1_i32_sized_slice(
+        &self,
+        location: Option<&Self::UniformLocation>,
+        v: &[i32; 1],
+    ) {
+        let gl = &self.raw;
+        gl.Uniform1iv(*location.unwrap_or(&0) as i32, v.len() as i32, v.as_ptr());
+    }
+
+    unsafe fn uniform_2_i32_sized_slice(
+        &self,
+        location: Option<&Self::UniformLocation>,
+        v: &[i32; 2],
+    ) {
+        let gl = &self.raw;
+        gl.Uniform2iv(*location.unwrap_or(&0) as i32, v.len() as i32 / 2, v.as_ptr());
+    }
+
+    unsafe fn uniform_3_i32_sized_slice(
+        &self,
+        location: Option<&Self::UniformLocation>,
+        v: &[i32; 3],
+    ) {
+        let gl = &self.raw;
+        gl.Uniform3iv(*location.unwrap_or(&0) as i32, v.len() as i32 / 3, v.as_ptr());
+    }
+
+    unsafe fn uniform_4_i32_sized_slice(
+        &self,
+        location: Option<&Self::UniformLocation>,
+        v: &[i32; 4],
+    ) {
+        let gl = &self.raw;
+        gl.Uniform4iv(*location.unwrap_or(&0) as i32, v.len() as i32 / 4, v.as_ptr());
+    }
+
     unsafe fn uniform_1_f32(&self, location: Option<&Self::UniformLocation>, x: f32) {
         let gl = &self.raw;
         gl.Uniform1f(*location.unwrap_or(&0) as i32, x);
@@ -1206,6 +1242,26 @@ impl HasContext for Context {
         gl.Uniform4fv(*location.unwrap_or(&0) as i32, v.len() as i32 / 4, v.as_ptr());
     }
 
+    unsafe fn uniform_1_f32_sized_slice(&self, location: Option<&Self::UniformLocation>, v: &[f32; 1]) {
+        let gl = &self.raw;
+        gl.Uniform1fv(*location.unwrap_or(&0) as i32, v.len() as i32, v.as_ptr());
+    }
+
+    unsafe fn uniform_2_f32_sized_slice(&self, location: Option<&Self::UniformLocation>, v: &[f32; 2]) {
+        let gl = &self.raw;
+        gl.Uniform2fv(*location.unwrap_or(&0) as i32, v.len() as i32 / 2, v.as_ptr());
+    }
+
+    unsafe fn uniform_3_f32_sized_slice(&self, location: Option<&Self::UniformLocation>, v: &[f32; 3]) {
+        let gl = &self.raw;
+        gl.Uniform3fv(*location.unwrap_or(&0) as i32, v.len() as i32 / 3, v.as_ptr());
+    }
+
+    unsafe fn uniform_4_f32_sized_slice(&self, location: Option<&Self::UniformLocation>, v: &[f32; 4]) {
+        let gl = &self.raw;
+        gl.Uniform4fv(*location.unwrap_or(&0) as i32, v.len() as i32 / 4, v.as_ptr());
+    }
+
     unsafe fn uniform_matrix_2_f32_slice(
         &self,
         location: Option<&Self::UniformLocation>,
@@ -1231,6 +1287,36 @@ impl HasContext for Context {
         location: Option<&Self::UniformLocation>,
         transpose: bool,
         v: &[f32],
+    ) {
+        let gl = &self.raw;
+        gl.UniformMatrix4fv(*location.unwrap_or(&0) as i32, v.len() as i32 / 16, transpose as u8, v.as_ptr());
+    }
+
+    unsafe fn uniform_matrix_2_f32_sized_slice(
+        &self,
+        location: Option<&Self::UniformLocation>,
+        transpose: bool,
+        v: &[f32; 4],
+    ) {
+        let gl = &self.raw;
+        gl.UniformMatrix2fv(*location.unwrap_or(&0) as i32, v.len() as i32 / 4, transpose as u8, v.as_ptr());
+    }
+
+    unsafe fn uniform_matrix_3_f32_sized_slice(
+        &self,
+        location: Option<&Self::UniformLocation>,
+        transpose: bool,
+        v: &[f32; 9],
+    ) {
+        let gl = &self.raw;
+        gl.UniformMatrix3fv(*location.unwrap_or(&0) as i32, v.len() as i32 / 9, transpose as u8, v.as_ptr());
+    }
+
+    unsafe fn uniform_matrix_4_f32_sized_slice(
+        &self,
+        location: Option<&Self::UniformLocation>,
+        transpose: bool,
+        v: &[f32; 16],
     ) {
         let gl = &self.raw;
         gl.UniformMatrix4fv(*location.unwrap_or(&0) as i32, v.len() as i32 / 16, transpose as u8, v.as_ptr());

--- a/src/stdweb.rs
+++ b/src/stdweb.rs
@@ -1696,6 +1696,66 @@ impl HasContext for Context {
         }
     }
 
+    unsafe fn uniform_1_i32_sized_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        v: &[i32; 1],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => {
+                gl.uniform1iv(uniform_location, &v[..])
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform1iv_1(uniform_location, &v[..])
+            }
+        }
+    }
+
+    unsafe fn uniform_2_i32_sized_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        v: &[i32; 2],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => {
+                gl.uniform2iv(uniform_location, &v[..])
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform2iv_1(uniform_location, &v[..])
+            }
+        }
+    }
+
+    unsafe fn uniform_3_i32_sized_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        v: &[i32; 3],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => {
+                gl.uniform3iv(uniform_location, &v[..])
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform3iv_1(uniform_location, &v[..])
+            }
+        }
+    }
+
+    unsafe fn uniform_4_i32_sized_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        v: &[i32; 4],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => {
+                gl.uniform4iv(uniform_location, &v[..])
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform4iv_1(uniform_location, &v[..])
+            }
+        }
+    }
+
     unsafe fn uniform_1_f32(&self, uniform_location: Option<&Self::UniformLocation>, x: f32) {
         match self.raw {
             RawRenderingContext::WebGl1(ref gl) => gl.uniform1f(uniform_location, x),
@@ -1802,6 +1862,66 @@ impl HasContext for Context {
         }
     }
 
+    unsafe fn uniform_1_f32_sized_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        v: &[f32; 1],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => {
+                gl.uniform1fv(uniform_location, &v[..])
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform1fv_1(uniform_location, &v[..])
+            }
+        }
+    }
+
+    unsafe fn uniform_2_f32_sized_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        v: &[f32; 2],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => {
+                gl.uniform2fv(uniform_location, &v[..])
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform2fv_1(uniform_location, &v[..])
+            }
+        }
+    }
+
+    unsafe fn uniform_3_f32_sized_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        v: &[f32; 3],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => {
+                gl.uniform3fv(uniform_location, &v[..])
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform3fv_1(uniform_location, &v[..])
+            }
+        }
+    }
+
+    unsafe fn uniform_4_f32_sized_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        v: &[f32; 4],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => {
+                gl.uniform4fv(uniform_location, &v[..])
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform4fv_1(uniform_location, &v[..])
+            }
+        }
+    }
+
     unsafe fn uniform_matrix_2_f32_slice(
         &self,
         uniform_location: Option<&Self::UniformLocation>,
@@ -1839,6 +1959,54 @@ impl HasContext for Context {
         uniform_location: Option<&Self::UniformLocation>,
         transpose: bool,
         v: &[f32],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => {
+                gl.uniform_matrix4fv(uniform_location, transpose, &v[..])
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform_matrix4fv_1(uniform_location, transpose, &v[..])
+            }
+        }
+    }
+
+    unsafe fn uniform_matrix_2_f32_sized_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        transpose: bool,
+        v: &[f32; 4],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => {
+                gl.uniform_matrix2fv(uniform_location, transpose, &v[..])
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform_matrix2fv_1(uniform_location, transpose, &v[..])
+            }
+        }
+    }
+
+    unsafe fn uniform_matrix_3_f32_sized_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        transpose: bool,
+        v: &[f32; 9],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => {
+                gl.uniform_matrix3fv(uniform_location, transpose, &v[..])
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform_matrix3fv_1(uniform_location, transpose, &v[..])
+            }
+        }
+    }
+
+    unsafe fn uniform_matrix_4_f32_sized_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        transpose: bool,
+        v: &[f32; 16],
     ) {
         match self.raw {
             RawRenderingContext::WebGl1(ref gl) => {

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -1845,6 +1845,66 @@ impl HasContext for Context {
         }
     }
 
+    unsafe fn uniform_1_i32_sized_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        v: &[i32; 1],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => {
+                gl.uniform1iv_with_i32_array(uniform_location, v)
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform1iv_with_i32_array(uniform_location, v)
+            }
+        }
+    }
+
+    unsafe fn uniform_2_i32_sized_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        v: &[i32; 2],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => {
+                gl.uniform2iv_with_i32_array(uniform_location, v)
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform2iv_with_i32_array(uniform_location, v)
+            }
+        }
+    }
+
+    unsafe fn uniform_3_i32_sized_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        v: &[i32; 3],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => {
+                gl.uniform3iv_with_i32_array(uniform_location, v)
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform3iv_with_i32_array(uniform_location, v)
+            }
+        }
+    }
+
+    unsafe fn uniform_4_i32_sized_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        v: &[i32; 4],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => {
+                gl.uniform4iv_with_i32_array(uniform_location, v)
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform4iv_with_i32_array(uniform_location, v)
+            }
+        }
+    }
+
     unsafe fn uniform_1_f32(&self, uniform_location: Option<&Self::UniformLocation>, x: f32) {
         match self.raw {
             RawRenderingContext::WebGl1(ref gl) => gl.uniform1f(uniform_location, x),
@@ -1951,6 +2011,66 @@ impl HasContext for Context {
         }
     }
 
+    unsafe fn uniform_1_f32_sized_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        v: &[f32; 1],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => {
+                gl.uniform1fv_with_f32_array(uniform_location, v)
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform1fv_with_f32_array(uniform_location, v)
+            }
+        }
+    }
+
+    unsafe fn uniform_2_f32_sized_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        v: &[f32; 2],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => {
+                gl.uniform2fv_with_f32_array(uniform_location, v)
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform2fv_with_f32_array(uniform_location, v)
+            }
+        }
+    }
+
+    unsafe fn uniform_3_f32_sized_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        v: &[f32; 3],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => {
+                gl.uniform3fv_with_f32_array(uniform_location, v)
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform3fv_with_f32_array(uniform_location, v)
+            }
+        }
+    }
+
+    unsafe fn uniform_4_f32_sized_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        v: &[f32; 4],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => {
+                gl.uniform4fv_with_f32_array(uniform_location, v)
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform4fv_with_f32_array(uniform_location, v)
+            }
+        }
+    }
+
     unsafe fn uniform_matrix_2_f32_slice(
         &self,
         uniform_location: Option<&Self::UniformLocation>,
@@ -1988,6 +2108,54 @@ impl HasContext for Context {
         uniform_location: Option<&Self::UniformLocation>,
         transpose: bool,
         v: &[f32],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => {
+                gl.uniform_matrix4fv_with_f32_array(uniform_location, transpose, v)
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform_matrix4fv_with_f32_array(uniform_location, transpose, v)
+            }
+        }
+    }
+
+    unsafe fn uniform_matrix_2_f32_sized_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        transpose: bool,
+        v: &[f32; 4],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => {
+                gl.uniform_matrix2fv_with_f32_array(uniform_location, transpose, v)
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform_matrix2fv_with_f32_array(uniform_location, transpose, v)
+            }
+        }
+    }
+
+    unsafe fn uniform_matrix_3_f32_sized_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        transpose: bool,
+        v: &[f32; 9],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => {
+                gl.uniform_matrix3fv_with_f32_array(uniform_location, transpose, v)
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform_matrix3fv_with_f32_array(uniform_location, transpose, v)
+            }
+        }
+    }
+
+    unsafe fn uniform_matrix_4_f32_sized_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        transpose: bool,
+        v: &[f32; 16],
     ) {
         match self.raw {
             RawRenderingContext::WebGl1(ref gl) => {


### PR DESCRIPTION
Added _sized_slice() calls for glUniform*fv calls.

I implemented this because [cgmath](https://github.com/rustgd/cgmath) only allows returning sized array references for Matrix and Vector types.