### PR TITLE
Fix web_sys tex_image_2d FLOAT

### DIFF
--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -1638,10 +1638,21 @@ impl HasContext for Context {
         ty: u32,
         pixels: Option<&[u8]>,
     ) {
+        let pixels = pixels.map(|bytes| -> js_sys::Object {
+            match ty {
+                FLOAT => {
+                    let (_, data, _) = bytes.align_to::<f32>();
+                    js_sys::Float32Array::view(data).into()
+                },
+                _ => js_sys::Uint8Array::view(bytes).into()
+            }
+        });
+
+
         match self.raw {
             RawRenderingContext::WebGl1(ref gl) => {
                 // TODO: Handle return value?
-                gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array(
+                gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_array_buffer_view(
                     target,
                     level,
                     internal_format,
@@ -1650,13 +1661,13 @@ impl HasContext for Context {
                     border,
                     format,
                     ty,
-                    pixels,
+                    pixels.as_ref(),
                 )
                 .unwrap();
             }
             RawRenderingContext::WebGl2(ref gl) => {
                 // TODO: Handle return value?
-                gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array(
+                gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_array_buffer_view(
                     target,
                     level,
                     internal_format,
@@ -1665,7 +1676,7 @@ impl HasContext for Context {
                     border,
                     format,
                     ty,
-                    pixels,
+                    pixels.as_ref(),
                 )
                 .unwrap();
             }


### PR DESCRIPTION
When using a float texture, WebGL expect a `Float32Array`. The following error appears in the console (in chrome at least):

```
WebGL: INVALID_OPERATION: texImage2D: type FLOAT but ArrayBufferView not Float32Array
```

Let me know if you're ok with this approach, I guess other formats will require some mapping as well, but I'm not sure how all types should be used:

For future reference, typed array types:
```
Int8Array
Uint8Array
Uint8ClampedArray
Int16Array
Uint16Array
Int32Array
Uint32Array
Float32Array
Float64Array
BigInt64Array
BigUint64Array
```
*Sized Texture Color Formats* section could be usefull to check too here: https://www.khronos.org/files/webgl20-reference-guide.pdf