### PR TITLE
add get_uniform functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -476,6 +476,10 @@ pub trait HasContext {
         depth: i32,
     );
 
+    unsafe fn get_uniform_i32(&self, program: Self::Program, location: &Self::UniformLocation, v: &mut [i32]);
+
+    unsafe fn get_uniform_f32(&self, program: Self::Program, location: &Self::UniformLocation, v: &mut [f32]);
+
     unsafe fn uniform_1_i32(&self, location: Option<&Self::UniformLocation>, x: i32);
 
     unsafe fn uniform_2_i32(&self, location: Option<&Self::UniformLocation>, x: i32, y: i32);

--- a/src/native.rs
+++ b/src/native.rs
@@ -1084,6 +1084,16 @@ impl HasContext for Context {
         gl.TexStorage3D(target, levels, internal_format, width, height, depth);
     }
 
+    unsafe fn get_uniform_i32(&self, program: Self::Program, location: &Self::UniformLocation, v: &mut [i32]) {
+        let gl = &self.raw;
+        gl.GetUniformiv(program as u32, *location as i32, v.as_mut_ptr() as *mut i32)
+    }
+
+    unsafe fn get_uniform_f32(&self, program: Self::Program, location: &Self::UniformLocation, v: &mut [f32]) {
+        let gl = &self.raw;
+        gl.GetUniformfv(program as u32, *location as i32, v.as_mut_ptr() as *mut f32)
+    }
+
     unsafe fn uniform_1_i32(&self, location: Option<&Self::UniformLocation>, x: i32) {
         let gl = &self.raw;
         if let Some(loc) = location {

--- a/src/stdweb.rs
+++ b/src/stdweb.rs
@@ -2560,6 +2560,40 @@ impl HasContext for Context {
             RawRenderingContext::WebGl2(ref gl) => gl.read_pixels(x, y, width, height, format, gltype, Some(data as &[u8])),
         }
     }
+
+    unsafe fn get_uniform_i32(&self, program: Self::Program, location: &Self::UniformLocation, v: &mut [i32]) {
+        let programs = self.programs.borrow();
+        let raw_program = programs.1.get_unchecked(program);
+        let value = match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => gl.get_uniform(&raw_program, location),
+            RawRenderingContext::WebGl2(ref gl) => gl.get_uniform(&raw_program, location),
+        };
+        if let Some(value_reference) = value.as_reference() {
+            if let Ok(value) = TryInto::<std_web::web::TypedArray<i32>>::try_into(value_reference) {
+                let value: Vec<_> = value.into();
+                v.copy_from_slice(&value);
+            }
+        } else if let Ok(value) = TryInto::<i32>::try_into(value) {
+            v[0] = value;
+        }
+    }
+
+    unsafe fn get_uniform_f32(&self, program: Self::Program, location: &Self::UniformLocation, v: &mut [f32]) {
+        let programs = self.programs.borrow();
+        let raw_program = programs.1.get_unchecked(program);
+        let value = match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => gl.get_uniform(&raw_program, location),
+            RawRenderingContext::WebGl2(ref gl) => gl.get_uniform(&raw_program, location),
+        };
+        if let Some(value_reference) = value.as_reference() {
+            if let Ok(value) = TryInto::<std_web::web::TypedArray<f32>>::try_into(value_reference) {
+                let value: Vec<_> = value.into();
+                v.copy_from_slice(&value);
+            }
+        } else if let Ok(value) = TryInto::<f64>::try_into(value) {
+            v[0] = value as f32;
+        }
+    }
 }
 
 pub struct RenderLoop;

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -2714,6 +2714,36 @@ impl HasContext for Context {
                 .unwrap(),
         }
     }
+
+    unsafe fn get_uniform_i32(&self, program: Self::Program, location: &Self::UniformLocation, v: &mut [i32]) {
+        let programs = self.programs.borrow();
+        let raw_program = programs.1.get_unchecked(program);
+        let value = match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => gl.get_uniform(&raw_program, location),
+            RawRenderingContext::WebGl2(ref gl) => gl.get_uniform(&raw_program, location),
+        };
+        use wasm_bindgen::JsCast;
+        if let Some(value) = value.as_f64() {
+            v[0] = value as i32;
+        } else if let Some(values) = value.dyn_ref::<js_sys::Int32Array>() {
+            values.copy_to(v)
+        }
+    }
+
+    unsafe fn get_uniform_f32(&self, program: Self::Program, location: &Self::UniformLocation, v: &mut [f32]) {
+        let programs = self.programs.borrow();
+        let raw_program = programs.1.get_unchecked(program);
+        let value = match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => gl.get_uniform(&raw_program, location),
+            RawRenderingContext::WebGl2(ref gl) => gl.get_uniform(&raw_program, location),
+        };
+        use wasm_bindgen::JsCast;
+        if let Some(value) = value.as_f64() {
+            v[0] = value as f32;
+        } else if let Some(values) = value.dyn_ref::<js_sys::Float32Array>() {
+            values.copy_to(v)
+        }
+    }
 }
 
 pub struct RenderLoop;


### PR DESCRIPTION
Adds functions for getting existing uniform data from a program. This is especially useful for warming CPU-side caches.

The web APIs are a little annoying because WebGL's [getUniform](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/getUniform) can return a lot of different data types.

If someone knows how to get data out of a stdweb TypedArray without the Vec allocation, I'm very interested. Maybe @ryanisaacg? 