### PR TITLE
Add support for unsigned uniforms

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -499,6 +499,29 @@ pub trait HasContext {
 
     unsafe fn uniform_4_i32_slice(&self, location: Option<&Self::UniformLocation>, v: &[i32]);
 
+    unsafe fn uniform_1_u32(&self, location: Option<&Self::UniformLocation>, x: u32);
+
+    unsafe fn uniform_2_u32(&self, location: Option<&Self::UniformLocation>, x: u32, y: u32);
+
+    unsafe fn uniform_3_u32(&self, location: Option<&Self::UniformLocation>, x: u32, y: u32, z: u32);
+
+    unsafe fn uniform_4_u32(
+        &self,
+        location: Option<&Self::UniformLocation>,
+        x: u32,
+        y: u32,
+        z: u32,
+        w: u32,
+    );
+
+    unsafe fn uniform_1_u32_slice(&self, location: Option<&Self::UniformLocation>, v: &[u32]);
+
+    unsafe fn uniform_2_u32_slice(&self, location: Option<&Self::UniformLocation>, v: &[u32]);
+
+    unsafe fn uniform_3_u32_slice(&self, location: Option<&Self::UniformLocation>, v: &[u32]);
+
+    unsafe fn uniform_4_u32_slice(&self, location: Option<&Self::UniformLocation>, v: &[u32]);
+
     unsafe fn uniform_1_f32(&self, location: Option<&Self::UniformLocation>, x: f32);
 
     unsafe fn uniform_2_f32(&self, location: Option<&Self::UniformLocation>, x: f32, y: f32);

--- a/src/native.rs
+++ b/src/native.rs
@@ -1169,6 +1169,91 @@ impl HasContext for Context {
         }
     }
 
+    unsafe fn uniform_1_u32(&self, location: Option<&Self::UniformLocation>, x: u32) {
+        let gl = &self.raw;
+        if let Some(loc) = location {
+            gl.Uniform1ui(*loc as i32, x);
+        }
+    }
+
+    unsafe fn uniform_2_u32(&self, location: Option<&Self::UniformLocation>, x: u32, y: u32) {
+        let gl = &self.raw;
+        if let Some(loc) = location {
+            gl.Uniform2ui(*loc as i32, x, y);
+        }
+    }
+
+    unsafe fn uniform_3_u32(
+        &self,
+        location: Option<&Self::UniformLocation>,
+        x: u32,
+        y: u32,
+        z: u32,
+    ) {
+        let gl = &self.raw;
+        if let Some(loc) = location {
+            gl.Uniform3ui(*loc as i32, x, y, z);
+        }
+    }
+
+    unsafe fn uniform_4_u32(
+        &self,
+        location: Option<&Self::UniformLocation>,
+        x: u32,
+        y: u32,
+        z: u32,
+        w: u32,
+    ) {
+        let gl = &self.raw;
+        if let Some(loc) = location {
+            gl.Uniform4ui(*loc as i32, x, y, z, w);
+        }
+    }
+
+    unsafe fn uniform_1_u32_slice(
+        &self,
+        location: Option<&Self::UniformLocation>,
+        v: &[u32],
+    ) {
+        let gl = &self.raw;
+        if let Some(loc) = location {
+            gl.Uniform1uiv(*loc as i32, v.len() as i32, v.as_ptr());
+        }
+    }
+
+    unsafe fn uniform_2_u32_slice(
+        &self,
+        location: Option<&Self::UniformLocation>,
+        v: &[u32],
+    ) {
+        let gl = &self.raw;
+        if let Some(loc) = location {
+            gl.Uniform2uiv(*loc as i32, v.len() as i32 / 2, v.as_ptr());
+        }
+    }
+
+    unsafe fn uniform_3_u32_slice(
+        &self,
+        location: Option<&Self::UniformLocation>,
+        v: &[u32],
+    ) {
+        let gl = &self.raw;
+        if let Some(loc) = location {
+            gl.Uniform3uiv(*loc as i32, v.len() as i32 / 3, v.as_ptr());
+        }
+    }
+
+    unsafe fn uniform_4_u32_slice(
+        &self,
+        location: Option<&Self::UniformLocation>,
+        v: &[u32],
+    ) {
+        let gl = &self.raw;
+        if let Some(loc) = location {
+            gl.Uniform4uiv(*loc as i32, v.len() as i32 / 4, v.as_ptr());
+        }
+    }
+
     unsafe fn uniform_1_f32(&self, location: Option<&Self::UniformLocation>, x: f32) {
         let gl = &self.raw;
         if let Some(loc) = location {

--- a/src/stdweb.rs
+++ b/src/stdweb.rs
@@ -1764,6 +1764,112 @@ impl HasContext for Context {
         }
     }
 
+    unsafe fn uniform_1_u32(&self, uniform_location: Option<&Self::UniformLocation>, x: u32) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref _gl) => panic!("Unsigned uniforms are not supported"),
+            RawRenderingContext::WebGl2(ref gl) => gl.uniform1ui(uniform_location, x),
+        }
+    }
+
+    unsafe fn uniform_2_u32(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        x: u32,
+        y: u32,
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref _gl) => panic!("Unsigned uniforms are not supported"),
+            RawRenderingContext::WebGl2(ref gl) => gl.uniform2ui(uniform_location, x, y),
+        }
+    }
+
+    unsafe fn uniform_3_u32(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        x: u32,
+        y: u32,
+        z: u32,
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref _gl) => panic!("Unsigned uniforms are not supported"),
+            RawRenderingContext::WebGl2(ref gl) => gl.uniform3ui(uniform_location, x, y, z),
+        }
+    }
+
+    unsafe fn uniform_4_u32(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        x: u32,
+        y: u32,
+        z: u32,
+        w: u32,
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref _gl) => panic!("Unsigned uniforms are not supported"),
+            RawRenderingContext::WebGl2(ref gl) => gl.uniform4ui(uniform_location, x, y, z, w),
+        }
+    }
+
+    unsafe fn uniform_1_u32_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        v: &[u32],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref _gl) => {
+                panic!("Unsigned uniforms are not supported");
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform1uiv(uniform_location, &v[..], 0, v.len() as u32)
+            }
+        }
+    }
+
+    unsafe fn uniform_2_u32_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        v: &[u32],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref _gl) => {
+                panic!("Unsigned uniforms are not supported");
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform2uiv(uniform_location, &v[..], 0, v.len() as u32)
+            }
+        }
+    }
+
+    unsafe fn uniform_3_u32_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        v: &[u32],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref _gl) => {
+                panic!("Unsigned uniforms are not supported");
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform3uiv(uniform_location, &v[..], 0, v.len() as u32)
+            }
+        }
+    }
+
+    unsafe fn uniform_4_u32_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        v: &[u32],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref _gl) => {
+                panic!("Unsigned uniforms are not supported");
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform4uiv(uniform_location, &v[..], 0, v.len() as u32)
+            }
+        }
+    }
+
     unsafe fn uniform_1_f32(&self, uniform_location: Option<&Self::UniformLocation>, x: f32) {
         match self.raw {
             RawRenderingContext::WebGl1(ref gl) => gl.uniform1f(uniform_location, x),

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -1911,6 +1911,112 @@ impl HasContext for Context {
         }
     }
 
+    unsafe fn uniform_1_u32(&self, uniform_location: Option<&Self::UniformLocation>, x: u32) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref _gl) => panic!("Unsigned uniforms are not supported"),
+            RawRenderingContext::WebGl2(ref gl) => gl.uniform1ui(uniform_location, x),
+        }
+    }
+
+    unsafe fn uniform_2_u32(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        x: u32,
+        y: u32,
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref _gl) => panic!("Unsigned uniforms are not supported"),
+            RawRenderingContext::WebGl2(ref gl) => gl.uniform2ui(uniform_location, x, y),
+        }
+    }
+
+    unsafe fn uniform_3_u32(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        x: u32,
+        y: u32,
+        z: u32,
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref _gl) => panic!("Unsigned uniforms are not supported"),
+            RawRenderingContext::WebGl2(ref gl) => gl.uniform3ui(uniform_location, x, y, z),
+        }
+    }
+
+    unsafe fn uniform_4_u32(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        x: u32,
+        y: u32,
+        z: u32,
+        w: u32,
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref _gl) => panic!("Unsigned uniforms are not supported"),
+            RawRenderingContext::WebGl2(ref gl) => gl.uniform4ui(uniform_location, x, y, z, w),
+        }
+    }
+
+    unsafe fn uniform_1_u32_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        v: &[u32],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref _gl) => {
+                panic!("Unsigned uniforms are not supported");
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform1uiv_with_u32_array(uniform_location, v)
+            }
+        }
+    }
+
+    unsafe fn uniform_2_u32_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        v: &[u32],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref _gl) => {
+                panic!("Unsigned uniforms are not supported");
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform2uiv_with_u32_array(uniform_location, v)
+            }
+        }
+    }
+
+    unsafe fn uniform_3_u32_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        v: &[u32],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref _gl) => {
+                panic!("Unsigned uniforms are not supported");
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform3uiv_with_u32_array(uniform_location, v)
+            }
+        }
+    }
+
+    unsafe fn uniform_4_u32_slice(
+        &self,
+        uniform_location: Option<&Self::UniformLocation>,
+        v: &[u32],
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref _gl) => {
+                panic!("Unsigned uniforms are not supported");
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.uniform4uiv_with_u32_array(uniform_location, v)
+            }
+        }
+    }
+
     unsafe fn uniform_1_f32(&self, uniform_location: Option<&Self::UniformLocation>, x: f32) {
         match self.raw {
             RawRenderingContext::WebGl1(ref gl) => gl.uniform1f(uniform_location, x),


### PR DESCRIPTION
This works for OpenGL desktop and WebGL2, however WebGL1 doesn't have the required glUniform*ui calls available thus the corresponding methods will panic.

I think it's ok to add these even if they're not supported by WebGL1, some other methods (`bind_sampler`, `fence_sync`, and others) already follow this pattern.