### PR TITLE
Add query objects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ features = [
   "WebGlBuffer",
   "WebGlFramebuffer",
   "WebGlProgram",
+  "WebGlQuery",
   "WebGlRenderbuffer",
   "WebGlRenderingContext",
   "WebGl2RenderingContext",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ pub type Sampler = <Context as HasContext>::Sampler;
 pub type Fence = <Context as HasContext>::Fence;
 pub type Framebuffer = <Context as HasContext>::Framebuffer;
 pub type Renderbuffer = <Context as HasContext>::Renderbuffer;
+pub type Query = <Context as HasContext>::Query;
 pub type UniformLocation = <Context as HasContext>::UniformLocation;
 
 pub struct ActiveUniform {
@@ -66,11 +67,14 @@ pub trait HasContext {
     type Fence: Copy + Clone + Debug + Eq + Hash + Ord + PartialEq + PartialOrd;
     type Framebuffer: Copy + Clone + Debug + Eq + Hash + Ord + PartialEq + PartialOrd;
     type Renderbuffer: Copy + Clone + Debug + Eq + Hash + Ord + PartialEq + PartialOrd;
+    type Query: Copy + Clone + Debug + Eq + Hash + Ord + PartialEq + PartialOrd;
     type UniformLocation: Clone + Debug;
 
     fn supports_debug(&self) -> bool;
 
     unsafe fn create_framebuffer(&self) -> Result<Self::Framebuffer, String>;
+
+    unsafe fn create_query(&self) -> Result<Self::Query, String>;
 
     unsafe fn create_renderbuffer(&self) -> Result<Self::Renderbuffer, String>;
 
@@ -231,6 +235,8 @@ pub trait HasContext {
     unsafe fn delete_buffer(&self, buffer: Self::Buffer);
 
     unsafe fn delete_framebuffer(&self, framebuffer: Self::Framebuffer);
+
+    unsafe fn delete_query(&self, query: Self::Query);
 
     unsafe fn delete_renderbuffer(&self, renderbuffer: Self::Renderbuffer);
 
@@ -831,6 +837,12 @@ pub trait HasContext {
     unsafe fn read_buffer(&self, src: u32);
 
     unsafe fn read_pixels(&self, x: i32, y: i32, width: i32, height: i32, format: u32, gltype: u32, data: &mut [u8]);
+
+    unsafe fn begin_query(&self, target: u32, query: Self::Query);
+
+    unsafe fn end_query(&self, target: u32);
+
+    unsafe fn get_query_parameter_u32(&self, query: Self::Query, parameter: u32) -> u32;
 }
 
 pub trait HasRenderLoop {

--- a/src/native.rs
+++ b/src/native.rs
@@ -70,6 +70,7 @@ impl HasContext for Context {
     type Fence = native_gl::types::GLsync;
     type Framebuffer = native_gl::types::GLuint;
     type Renderbuffer = native_gl::types::GLuint;
+    type Query = native_gl::types::GLuint;
     type UniformLocation = native_gl::types::GLuint;
 
     fn supports_debug(&self) -> bool {
@@ -80,6 +81,13 @@ impl HasContext for Context {
         let gl = &self.raw;
         let mut name = 0;
         gl.GenFramebuffers(1, &mut name);
+        Ok(name)
+    }
+
+    unsafe fn create_query(&self) -> Result<Self::Query, String> {
+        let gl = &self.raw;
+        let mut name = 0;
+        gl.GenQueries(1, &mut name);
         Ok(name)
     }
 
@@ -531,6 +539,11 @@ impl HasContext for Context {
     unsafe fn delete_framebuffer(&self, framebuffer: Self::Framebuffer) {
         let gl = &self.raw;
         gl.DeleteFramebuffers(1, &framebuffer);
+    }
+
+    unsafe fn delete_query(&self, query: Self::Query) {
+        let gl = &self.raw;
+        gl.DeleteQueries(1, &query);
     }
 
     unsafe fn delete_renderbuffer(&self, renderbuffer: Self::Renderbuffer) {
@@ -2065,6 +2078,23 @@ impl HasContext for Context {
     ) {
         let gl = &self.raw;
         gl.ReadPixels(x, y, width, height, format, gltype, data.as_mut_ptr() as *mut std::ffi::c_void);
+    }
+
+    unsafe fn begin_query(&self, target: u32, query: Self::Query) {
+        let gl = &self.raw;
+        gl.BeginQuery(target, query);
+    }
+
+    unsafe fn end_query(&self, target: u32) {
+        let gl = &self.raw;
+        gl.EndQuery(target);
+    }
+
+    unsafe fn get_query_parameter_u32(&self, query: Self::Query, parameter: u32) -> u32 {
+        let gl = &self.raw;
+        let mut value = 0;
+        gl.GetQueryObjectuiv(query, parameter, &mut value);
+        value
     }
 }
 

--- a/src/stdweb.rs
+++ b/src/stdweb.rs
@@ -8,6 +8,7 @@ use webgl_stdweb::{
     WebGL2RenderingContext, WebGLBuffer, WebGLFramebuffer, WebGLProgram, WebGLRenderbuffer,
     WebGLRenderingContext, WebGLSampler, WebGLShader, WebGLSync, WebGLTexture,
     WebGLUniformLocation, WebGLVertexArrayObject, WebGLVertexArrayObjectOES,
+    WebGLQuery,
 };
 
 #[derive(Debug)]
@@ -80,6 +81,7 @@ pub struct Context {
     fences: TrackedResource<WebFenceKey, WebGLSync>,
     framebuffers: TrackedResource<WebFramebufferKey, WebGLFramebuffer>,
     renderbuffers: TrackedResource<WebRenderbufferKey, WebGLRenderbuffer>,
+    queries: TrackedResource<WebQueryKey, WebGLQuery>,
 }
 
 impl Context {
@@ -135,6 +137,7 @@ impl Context {
             fences: tracked_resource(),
             framebuffers: tracked_resource(),
             renderbuffers: tracked_resource(),
+            queries: tracked_resource(),
         }
     }
 
@@ -190,6 +193,7 @@ impl Context {
             fences: tracked_resource(),
             framebuffers: tracked_resource(),
             renderbuffers: tracked_resource(),
+            queries: tracked_resource(),
         }
     }
 }
@@ -203,6 +207,7 @@ new_key_type! { pub struct WebSamplerKey; }
 new_key_type! { pub struct WebFenceKey; }
 new_key_type! { pub struct WebFramebufferKey; }
 new_key_type! { pub struct WebRenderbufferKey; }
+new_key_type! { pub struct WebQueryKey; }
 
 impl HasContext for Context {
     type Shader = WebShaderKey;
@@ -214,6 +219,7 @@ impl HasContext for Context {
     type Fence = WebFenceKey;
     type Framebuffer = WebFramebufferKey;
     type Renderbuffer = WebRenderbufferKey;
+    type Query = WebQueryKey;
     type UniformLocation = WebGLUniformLocation;
 
     fn supports_debug(&self) -> bool {
@@ -233,6 +239,22 @@ impl HasContext for Context {
                 Ok(key)
             }
             None => Err(String::from("Unable to create framebuffer object")),
+        }
+    }
+
+    unsafe fn create_query(&self) -> Result<Self::Query, String> {
+        let raw_query = match self.raw {
+            RawRenderingContext::WebGl1(ref _gl) => { return Err(String::from("Query objects are not supported")); },
+            RawRenderingContext::WebGl2(ref gl) => gl.create_query(),
+        };
+
+        match raw_query {
+            Some(s) => {
+                let key = self.queries.borrow_mut().0.insert(());
+                self.queries.borrow_mut().1.insert(key, s);
+                Ok(key)
+            }
+            None => Err(String::from("Unable to create query object")),
         }
     }
 
@@ -884,6 +906,17 @@ impl HasContext for Context {
             Some(ref f) => match self.raw {
                 RawRenderingContext::WebGl1(ref gl) => gl.delete_framebuffer(Some(f)),
                 RawRenderingContext::WebGl2(ref gl) => gl.delete_framebuffer(Some(f)),
+            },
+            None => {}
+        }
+    }
+
+    unsafe fn delete_query(&self, query: Self::Query) {
+        let mut queries = self.queries.borrow_mut();
+        match queries.1.remove(query) {
+            Some(ref r) => match self.raw {
+                RawRenderingContext::WebGl1(ref _gl) => panic!("Query objects are not supported"),
+                RawRenderingContext::WebGl2(ref gl) => gl.delete_query(Some(r)),
             },
             None => {}
         }
@@ -2698,6 +2731,34 @@ impl HasContext for Context {
             }
         } else if let Ok(value) = TryInto::<f64>::try_into(value) {
             v[0] = value as f32;
+        }
+    }
+
+    unsafe fn begin_query(&self, target: u32, query: Self::Query) {
+        let queries = self.queries.borrow();
+        let raw_query = queries.1.get_unchecked(query);
+        match self.raw {
+            RawRenderingContext::WebGl1(ref _gl) => panic!("Query objects are not supported"),
+            RawRenderingContext::WebGl2(ref gl) => gl.begin_query(target, raw_query),
+        }
+    }
+
+    unsafe fn end_query(&self, target: u32) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref _gl) => panic!("Query objects are not supported"),
+            RawRenderingContext::WebGl2(ref gl) => gl.end_query(target),
+        }
+    }
+
+    unsafe fn get_query_parameter_u32(&self, query: Self::Query, parameter: u32) -> u32 {
+        let queries = self.queries.borrow();
+        let raw_query = queries.1.get_unchecked(query);
+        match self.raw {
+            RawRenderingContext::WebGl1(ref _gl) => panic!("Query objects are not supported"),
+            RawRenderingContext::WebGl2(ref gl) => gl.get_query_parameter(raw_query, parameter)
+                .try_into()
+                .map(|v: f64| v as u32)
+                .unwrap_or(0),
         }
     }
 }


### PR DESCRIPTION
> Query Objects are OpenGL Objects that are used for asynchronous queries of certain kinds of information: https://www.khronos.org/opengl/wiki/Query_Object

This PR adds query objects, supported by OpenGL desktop and WebGL 2. On WebGL 1, the create_query method always returns an error. Other functions panic.

This adds:
* `create_query`: create a query object
* `delete_query`: delete a query object
* `begin_query`: start a query for a target
* `end_query`: complete a query for a target
* `get_query_parameter_u32`: get the value of a query parameter