### PR TITLE
Update all dependencies, update clippy allowances

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,22 +19,22 @@ web-sys = ["web_sys", "js-sys", "wasm-bindgen"]
 stdweb = ["std_web", "webgl_stdweb"]
 
 [target.'cfg(not(any(target_arch = "wasm32")))'.dependencies]
-glutin = { version = "0.22.0", optional = true }
-sdl2 = { version = "0.32", optional = true }
+glutin = { version = "0.24", optional = true }
+sdl2 = { version = "0.33", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = { version = "~0.3", optional = true }
 wasm-bindgen = { version = "~0.2", optional = true }
 webgl_stdweb = { version = "0.3", optional = true }
-slotmap = "0.3"
+slotmap = "0.4"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.std_web]
-version = "0.4.18"
+version = "0.4.20"
 package = "stdweb"
 optional = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web_sys]
-version = "~0.3.23"
+version = "~0.3.37"
 package = "web-sys"
 optional = true
 features = [
@@ -90,7 +90,7 @@ features = [
 ]
 
 [build-dependencies]
-gl_generator = "0.13"
+gl_generator = "0.14"
 
 [workspace]
 members = [

--- a/examples/hello/Cargo.toml
+++ b/examples/hello/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 glow = { path = "../../", default-features=false }
 
 [target.'cfg(not(any(target_arch = "wasm32")))'.dependencies]
-glutin = { version = "0.22.0", optional = true }
-sdl2 = { version = "0.32", optional = true }
+glutin = { version = "0.24", optional = true }
+sdl2 = { version = "0.33", optional = true }
 
 [features]
 default = ["web-sys"]
@@ -20,5 +20,5 @@ window-glutin = ["glutin", "glow/glutin"]
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web_sys = { version = "0.3", package = "web-sys", features=["console"], optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
-std_web  = { version = "0.4.18", package = "stdweb", optional = true }
+std_web  = { version = "0.4", package = "stdweb", optional = true }
 webgl_stdweb = { version = "0.3", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::unreadable_literal)]
+#![allow(clippy::missing_safety_doc)]
+#![allow(clippy::pedantic)] // For anyone using pedantic and a source dep, this is needed
 
 use core::fmt::Debug;
 use core::hash::Hash;

--- a/src/native.rs
+++ b/src/native.rs
@@ -4,6 +4,7 @@ use std::collections::HashSet;
 use std::ffi::CString;
 
 mod native_gl {
+    #![allow(clippy::all, clippy::pedantic)]
     include!(concat!(env!("OUT_DIR"), "/opengl_bindings.rs"));
 }
 
@@ -1912,7 +1913,7 @@ impl HasContext for Context {
     {
         let gl = &self.raw;
         gl.DebugMessageCallback(
-            raw_debug_message_callback::<F>,
+            Some(raw_debug_message_callback::<F>),
             &mut callback as *mut _ as *mut std::ffi::c_void,
         );
     }


### PR DESCRIPTION
This makes the following package updates, which all test file:

- `glutin` 0.22 -> 0.24 (this bumps winit internally too)
- `sdl2` 0.32 -> 0.33
- `slotmap` 0.3 -> 0.4
- `stdweb` 0.4.18 -> 0.4.20
- `web-sys` 0.3.23 -> 0.3.37
- `gl_generator` 0.13 -> 0.14 (This caused a change to Debug callbacks, requiring an option)
 
This PR also adds a few more clippy allowances, to prevent error/warning spamming from source dependencies (people that directly git clone locally + then build from that with clippy).
Mainly, clippy has added `clippy::missing_safety_doc` lint for unsafe functions. I've allowed this. Also added a blanket allow for `clippy::pedantic`, as I use it. Last, I added clippy blanket allowances for the entire opengl_binding module, to prevent generated code clippy warnings.