### PR TITLE
Simplify the example a bit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.38.0
+  - 1.40.0
   - stable
   - beta
   - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.37.0
+  - 1.38.0
   - stable
   - beta
   - nightly

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </div>
 <br />
 <div align="center">
-  <img src="https://img.shields.io/badge/Min%20Rust-1.37-green.svg" alt="Minimum Rust Version">
+  <img src="https://img.shields.io/badge/Min%20Rust-1.38-green.svg" alt="Minimum Rust Version">
   <a href="https://crates.io/crates/glow"><img src="https://img.shields.io/crates/v/glow.svg?label=glow" alt="crates.io"></a>
   <a href="https://docs.rs/glow"><img src="https://docs.rs/glow/badge.svg" alt="docs.rs"></a>
   <a href="https://travis-ci.org/grovesNL/glow"><img src="https://travis-ci.org/grovesNL/glow.svg?branch=master" alt="Travis Build Status" /></a>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </div>
 <br />
 <div align="center">
-  <img src="https://img.shields.io/badge/Min%20Rust-1.38-green.svg" alt="Minimum Rust Version">
+  <img src="https://img.shields.io/badge/Min%20Rust-1.40-green.svg" alt="Minimum Rust Version">
   <a href="https://crates.io/crates/glow"><img src="https://img.shields.io/crates/v/glow.svg?label=glow" alt="crates.io"></a>
   <a href="https://docs.rs/glow"><img src="https://docs.rs/glow/badge.svg" alt="docs.rs"></a>
   <a href="https://travis-ci.org/grovesNL/glow"><img src="https://travis-ci.org/grovesNL/glow.svg?branch=master" alt="Travis Build Status" /></a>

--- a/examples/hello/README.md
+++ b/examples/hello/README.md
@@ -21,9 +21,9 @@ cargo run --features=window-sdl2
 To run with web-sys:
 
 ```shell
-cargo +nightly build --target wasm32-unknown-unknown
+cargo build --target wasm32-unknown-unknown
 mkdir -p generated
-wasm-bindgen ../../target/wasm32-unknown-unknown/debug/hello.wasm --out-dir generated --no-modules
+wasm-bindgen ../../target/wasm32-unknown-unknown/debug/hello.wasm --out-dir generated --target web
 cp index.html generated
 ```
 

--- a/examples/hello/index.html
+++ b/examples/hello/index.html
@@ -5,10 +5,10 @@
   <body>
     <canvas id="canvas" width="640" height="480"></canvas>
     <script src="./hello.js"></script>
-    <script>
-      window.addEventListener("load", async () => {
-        await wasm_bindgen("./hello_bg.wasm");
-      });
+    <script type="module">
+      import init from "./hello.js";
+
+      init();
     </script>
   </body>
 </html>

--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -1,21 +1,14 @@
 use glow::*;
 
-#[cfg(all(target_arch = "wasm32", feature = "web-sys"))]
-use wasm_bindgen::prelude::*;
-
 #[cfg(all(target_arch = "wasm32", feature = "stdweb"))]
 use std_web::{
     traits::*,
     unstable::TryInto,
     web::{document, html_element::*},
 };
+
 #[cfg(all(target_arch = "wasm32", feature = "stdweb"))]
 use webgl_stdweb::WebGL2RenderingContext;
-
-#[cfg_attr(all(target_arch = "wasm32", feature = "web-sys"), wasm_bindgen(start))]
-pub fn wasm_main() {
-    main();
-}
 
 fn main() {
     unsafe {


### PR DESCRIPTION
Here's a few tweaks that make the example a bit simpler/up-to-date:

* A seperate `wasm_main` is no longer required due to https://github.com/rustwasm/wasm-bindgen/pull/1843.
* The prelude import wasn't actually being used anywhere.
* Nightly is no longer required to build this project, so I removed that from the instructions.
* `--no-modules` has been replaced with `--target web`, which doesn't rely on global variables and allows support for [JS snippets](https://rustwasm.github.io/docs/wasm-bindgen/reference/js-snippets.html).
    * The only caveat to this is that the generates JS is a ES module instead of a basic JS file - but any browser that supports WASM will also support ES modules, so I don't think this is an issue in practice.