### PR TITLE
Fix mutability of data in get_tex_image and buffer_storage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ pub trait HasContext {
         level: i32,
         format: u32,
         ty: u32,
-        pixels: Option<&[u8]>,
+        pixels: Option<&mut [u8]>,
     );
 
     unsafe fn get_tex_image_pixel_buffer_offset(
@@ -216,7 +216,7 @@ pub trait HasContext {
 
     unsafe fn get_buffer_sub_data(&self, target: u32, offset: i32, dst_data: &mut [u8]);
 
-    unsafe fn buffer_storage(&self, target: u32, size: i32, data: Option<&mut [u8]>, flags: u32);
+    unsafe fn buffer_storage(&self, target: u32, size: i32, data: Option<&[u8]>, flags: u32);
 
     unsafe fn check_framebuffer_status(&self, target: u32) -> u32;
 

--- a/src/native.rs
+++ b/src/native.rs
@@ -172,7 +172,7 @@ impl HasContext for Context {
         level: i32,
         format: u32,
         ty: u32,
-        pixels: Option<&[u8]>,
+        pixels: Option<&mut [u8]>,
     ) {
         let gl = &self.raw;
         gl.GetTexImage(
@@ -180,7 +180,9 @@ impl HasContext for Context {
             level,
             format,
             ty,
-            pixels.map(|p| p.as_ptr()).unwrap_or(std::ptr::null()) as *mut std::ffi::c_void,
+            pixels
+                .map(|p| p.as_mut_ptr())
+                .unwrap_or(std::ptr::null_mut()) as *mut std::ffi::c_void,
         );
     }
 
@@ -469,7 +471,7 @@ impl HasContext for Context {
         );
     }
 
-    unsafe fn buffer_storage(&self, target: u32, size: i32, data: Option<&mut [u8]>, flags: u32) {
+    unsafe fn buffer_storage(&self, target: u32, size: i32, data: Option<&[u8]>, flags: u32) {
         let gl = &self.raw;
         gl.BufferStorage(
             target,

--- a/src/stdweb.rs
+++ b/src/stdweb.rs
@@ -434,7 +434,7 @@ impl HasContext for Context {
         _level: i32,
         _format: u32,
         _ty: u32,
-        _pixels: Option<&[u8]>,
+        _pixels: Option<&mut [u8]>,
     ) {
         panic!("Get tex image is not supported");
     }
@@ -857,13 +857,7 @@ impl HasContext for Context {
         }
     }
 
-    unsafe fn buffer_storage(
-        &self,
-        _target: u32,
-        _size: i32,
-        _data: Option<&mut [u8]>,
-        _flags: u32,
-    ) {
+    unsafe fn buffer_storage(&self, _target: u32, _size: i32, _data: Option<&[u8]>, _flags: u32) {
         panic!("Buffer storage is not supported");
     }
 

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -538,7 +538,7 @@ impl HasContext for Context {
         _level: i32,
         _format: u32,
         _ty: u32,
-        _pixels: Option<&[u8]>,
+        _pixels: Option<&mut [u8]>,
     ) {
         panic!("Get tex image is not supported");
     }
@@ -943,13 +943,7 @@ impl HasContext for Context {
         }
     }
 
-    unsafe fn buffer_storage(
-        &self,
-        _target: u32,
-        _size: i32,
-        _data: Option<&mut [u8]>,
-        _flags: u32,
-    ) {
+    unsafe fn buffer_storage(&self, _target: u32, _size: i32, _data: Option<&[u8]>, _flags: u32) {
         panic!("Buffer storage is not supported");
     }
 


### PR DESCRIPTION
I think this should be a patch release, since the previous behavior was dangerous and UB.