### PR TITLE
Bump the patch version to 0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glow"
-version = "0.4.0"
+version = "0.4.1"
 description = "GL on Whatever: a set of bindings to run GL anywhere (Open GL, OpenGL ES, and WebGL) and avoid target-specific code."
 authors = ["Joshua Groves <josh@joshgroves.com>"]
 homepage = "https://github.com/grovesNL/glow.git"


### PR DESCRIPTION
Let's release?
Edit: also, let's have the branches for released breaking versions (i.e. v0.4)