### PR TITLE
Make docs for wasm32 available on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,18 @@ repository = "https://github.com/grovesNL/glow"
 license = "MIT OR Apache-2.0"
 edition = "2018"
 
+[package.metadata.docs.rs]
+features = ["web-sys"]
+default-target = "x86_64-unknown-linux-gnu"
+targets = [
+  "x86_64-unknown-linux-gnu",
+  "x86_64-apple-darwin",
+  "x86_64-pc-windows-msvc",
+  "i686-unknown-linux-gnu",
+  "i686-pc-windows-msvc",
+  "wasm32-unknown-unknown"
+]
+
 [lib]
 name = "glow"
 path = "src/lib.rs"


### PR DESCRIPTION
Added metadata to `Cargo.toml` so that docs for the target `wasm32-unknown-unknown` will be available on docs.rs. Only the `web-sys` feature is switched on as you can't have both `web-sys` and `stdweb` enabled.