### PR TITLE
Get parameter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,6 +396,12 @@ pub trait HasContext {
     unsafe fn get_buffer_parameter_i32(&self, target: u32, parameter: u32) -> i32;
 
     unsafe fn get_parameter_i32(&self, parameter: u32) -> i32;
+    
+    unsafe fn get_parameter_i32_slice(&self, parameter : u32, out : &mut[i32]);
+
+    unsafe fn get_parameter_f32(&self, parameter: u32) -> f32;
+
+    unsafe fn get_parameter_f32_slice(&self, parameter : u32, out : &mut[f32]);
 
     unsafe fn get_parameter_indexed_i32(&self, parameter: u32, index: u32) -> i32;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,12 +396,12 @@ pub trait HasContext {
     unsafe fn get_buffer_parameter_i32(&self, target: u32, parameter: u32) -> i32;
 
     unsafe fn get_parameter_i32(&self, parameter: u32) -> i32;
-    
-    unsafe fn get_parameter_i32_slice(&self, parameter : u32, out : &mut[i32]);
+
+    unsafe fn get_parameter_i32_slice(&self, parameter: u32, out: &mut [i32]);
 
     unsafe fn get_parameter_f32(&self, parameter: u32) -> f32;
 
-    unsafe fn get_parameter_f32_slice(&self, parameter : u32, out : &mut[f32]);
+    unsafe fn get_parameter_f32_slice(&self, parameter: u32, out: &mut [f32]);
 
     unsafe fn get_parameter_indexed_i32(&self, parameter: u32, index: u32) -> i32;
 

--- a/src/native.rs
+++ b/src/native.rs
@@ -21,16 +21,16 @@ impl Context {
     where
         F: FnMut(&str) -> *const std::os::raw::c_void,
     {
-
         // Note(Lokathor): This is wildly inefficient, because the loader_function
         // is doubtlessly just going to allocate the `&str` we pass into a new `CString`
         // so that it can pass that `*const c_char` off to the OS's actual loader.
         // However, this is the best we can do without changing the outer function
         // signature into something that's less alloc crazy.
-        let raw: native_gl::GlFns = native_gl::GlFns::load_with(|p: *const std::os::raw::c_char| {
-            let c_str = std::ffi::CStr::from_ptr(p);
-            loader_function(c_str.to_str().unwrap()) as *mut std::os::raw::c_void
-        });
+        let raw: native_gl::GlFns =
+            native_gl::GlFns::load_with(|p: *const std::os::raw::c_char| {
+                let c_str = std::ffi::CStr::from_ptr(p);
+                loader_function(c_str.to_str().unwrap()) as *mut std::os::raw::c_void
+            });
 
         // Setup extensions and constants after the context has been built
         let mut context = Self {
@@ -43,8 +43,7 @@ impl Context {
         // TODO: Use a fallback for versions < 3.0
         let num_extensions = context.get_parameter_i32(NUM_EXTENSIONS);
         for i in 0..num_extensions {
-            let extension_name =
-                context.get_parameter_indexed_string(EXTENSIONS, i as u32);
+            let extension_name = context.get_parameter_indexed_string(EXTENSIONS, i as u32);
             context.extensions.insert(extension_name);
         }
 
@@ -878,19 +877,19 @@ impl HasContext for Context {
         value
     }
 
-    unsafe fn get_parameter_i32_slice(&self, parameter : u32, out : &mut[i32]) {
+    unsafe fn get_parameter_i32_slice(&self, parameter: u32, out: &mut [i32]) {
         let gl = &self.raw;
         gl.GetIntegerv(parameter, &mut out[0]);
     }
-   
-    unsafe fn get_parameter_f32(&self, parameter: u32) -> f32{
+
+    unsafe fn get_parameter_f32(&self, parameter: u32) -> f32 {
         let gl = &self.raw;
-        let mut value : f32 = 0.0;
+        let mut value: f32 = 0.0;
         gl.GetFloatv(parameter, &mut value);
         value
     }
 
-    unsafe fn get_parameter_f32_slice(&self, parameter : u32, out : &mut[f32]){
+    unsafe fn get_parameter_f32_slice(&self, parameter: u32, out: &mut [f32]) {
         let gl = &self.raw;
         gl.GetFloatv(parameter, &mut out[0]);
     }

--- a/src/native.rs
+++ b/src/native.rs
@@ -878,6 +878,23 @@ impl HasContext for Context {
         value
     }
 
+    unsafe fn get_parameter_i32_slice(&self, parameter : u32, out : &mut[i32]) {
+        let gl = &self.raw;
+        gl.GetIntegerv(parameter, &mut out[0]);
+    }
+   
+    unsafe fn get_parameter_f32(&self, parameter: u32) -> f32{
+        let gl = &self.raw;
+        let mut value : f32 = 0.0;
+        gl.GetFloatv(parameter, &mut value);
+        value
+    }
+
+    unsafe fn get_parameter_f32_slice(&self, parameter : u32, out : &mut[f32]){
+        let gl = &self.raw;
+        gl.GetFloatv(parameter, &mut out[0]);
+    }
+
     unsafe fn get_parameter_indexed_i32(&self, parameter: u32, index: u32) -> i32 {
         let gl = &self.raw;
         let mut value = 0;

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -1556,12 +1556,12 @@ impl HasContext for Context {
         .unwrap_or(0)
     }
 
-    unsafe fn get_parameter_i32_slice(&self, parameter: u32, v : &mut[i32]) {
-
+    unsafe fn get_parameter_i32_slice(&self, parameter: u32, v: &mut [i32]) {
         let value = match self.raw {
             RawRenderingContext::WebGl1(ref gl) => gl.get_parameter(parameter),
             RawRenderingContext::WebGl2(ref gl) => gl.get_parameter(parameter),
-        }.unwrap();
+        }
+        .unwrap();
         use wasm_bindgen::JsCast;
         if let Some(value) = value.as_f64() {
             v[0] = value as i32;
@@ -1583,12 +1583,12 @@ impl HasContext for Context {
         .unwrap_or(0.0)
     }
 
-    unsafe fn get_parameter_f32_slice(&self, parameter: u32, v : &mut[f32]) {
-
+    unsafe fn get_parameter_f32_slice(&self, parameter: u32, v: &mut [f32]) {
         let value = match self.raw {
             RawRenderingContext::WebGl1(ref gl) => gl.get_parameter(parameter),
             RawRenderingContext::WebGl2(ref gl) => gl.get_parameter(parameter),
-        }.unwrap();
+        }
+        .unwrap();
         use wasm_bindgen::JsCast;
         if let Some(value) = value.as_f64() {
             v[0] = value as f32;
@@ -1596,7 +1596,6 @@ impl HasContext for Context {
             values.copy_to(v)
         }
     }
-
 
     unsafe fn get_parameter_indexed_i32(&self, parameter: u32, index: u32) -> i32 {
         match self.raw {

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -1556,6 +1556,48 @@ impl HasContext for Context {
         .unwrap_or(0)
     }
 
+    unsafe fn get_parameter_i32_slice(&self, parameter: u32, v : &mut[i32]) {
+
+        let value = match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => gl.get_parameter(parameter),
+            RawRenderingContext::WebGl2(ref gl) => gl.get_parameter(parameter),
+        }.unwrap();
+        use wasm_bindgen::JsCast;
+        if let Some(value) = value.as_f64() {
+            v[0] = value as i32;
+        } else if let Some(values) = value.dyn_ref::<js_sys::Int32Array>() {
+            values.copy_to(v)
+        }
+    }
+
+    unsafe fn get_parameter_f32(&self, parameter: u32) -> f32 {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => gl.get_parameter(parameter),
+            RawRenderingContext::WebGl2(ref gl) => gl.get_parameter(parameter),
+        }
+        .unwrap()
+        .as_f64()
+        .map(|v| v as f32)
+        // Errors will be caught by the browser or through `get_error`
+        // so return a default instead
+        .unwrap_or(0.0)
+    }
+
+    unsafe fn get_parameter_f32_slice(&self, parameter: u32, v : &mut[f32]) {
+
+        let value = match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => gl.get_parameter(parameter),
+            RawRenderingContext::WebGl2(ref gl) => gl.get_parameter(parameter),
+        }.unwrap();
+        use wasm_bindgen::JsCast;
+        if let Some(value) = value.as_f64() {
+            v[0] = value as f32;
+        } else if let Some(values) = value.dyn_ref::<js_sys::Float32Array>() {
+            values.copy_to(v)
+        }
+    }
+
+
     unsafe fn get_parameter_indexed_i32(&self, parameter: u32, index: u32) -> i32 {
         match self.raw {
             RawRenderingContext::WebGl1(ref _gl) => {


### PR DESCRIPTION
Hello, 
I added the following functions to the repo with the suggestions on the issue #146 

```
    unsafe fn get_parameter_i32(&self, parameter: u32) -> i32;
    unsafe fn get_parameter_i32_slice(&self, parameter: u32, out: &mut [i32]);
    unsafe fn get_parameter_f32(&self, parameter: u32) -> f32;
    unsafe fn get_parameter_f32_slice(&self, parameter: u32, out: &mut [f32]);
```
