### PR TITLE
Fix Docsrs Build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glow"
-version = "0.8.0"
+version = "0.8.1"
 description = "GL on Whatever: a set of bindings to run GL (Open GL, OpenGL ES, and WebGL) anywhere, and avoid target-specific code."
 authors = [
   "Joshua Groves <josh@joshgroves.com>",
@@ -12,7 +12,6 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [package.metadata.docs.rs]
-features = ["web-sys"]
 default-target = "x86_64-unknown-linux-gnu"
 targets = [
   "x86_64-unknown-linux-gnu",


### PR DESCRIPTION
Glow 0.8 didn't build on docsrs because the web-sys feature was removed. This should fix the issue. (Build logs: https://docs.rs/crate/glow/0.8.0/builds/357886)