### PR TITLE
Bump MSRV to 1.48

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         include:
         - build: pinned
           os: ubuntu-18.04
-          rust: 1.44.0
+          rust: 1.48.0
           sdl: true
         - build: stable
           os: ubuntu-18.04

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </div>
 <br />
 <div align="center">
-  <img src="https://img.shields.io/badge/Min%20Rust-1.44-green.svg" alt="Minimum Rust Version">
+  <img src="https://img.shields.io/badge/Min%20Rust-1.48-green.svg" alt="Minimum Rust Version">
   <a href="https://crates.io/crates/glow"><img src="https://img.shields.io/crates/v/glow.svg?label=glow" alt="crates.io"></a>
   <a href="https://docs.rs/glow"><img src="https://docs.rs/glow/badge.svg" alt="docs.rs"></a>
   <a href="https://github.com/grovesNL/glow/actions"><img src="https://github.com/grovesNL/glow/workflows/CI/badge.svg?branch=main" alt="Build Status" /></a>


### PR DESCRIPTION
This is necessary for SDL to use `#[doc(alias)]`, see https://github.com/grovesNL/glow/pull/153/checks?check_run_id=2271870678