### PR TITLE
Added glTexImage2DMultisample

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -497,6 +497,17 @@ pub trait HasContext {
         pixels: Option<&[u8]>,
     );
 
+    /// Not implemented for WebGL
+    unsafe fn tex_image_2d_multisample(
+        &self,
+        target: u32,
+        samples: i32,
+        internal_format: u32,
+        width: i32,
+        height: i32,
+        fixed_sample_locations: bool
+    );
+
     unsafe fn compressed_tex_image_2d(
         &self,
         target: u32,

--- a/src/native.rs
+++ b/src/native.rs
@@ -1131,6 +1131,26 @@ impl HasContext for Context {
         );
     }
 
+    unsafe fn tex_image_2d_multisample(
+        &self,
+        target: u32,
+        samples: i32,
+        internal_format: i32,
+        width: i32,
+        height: i32,
+        fixed_sample_locations: bool
+    ) {
+        let gl = &self.raw;
+        gl.TexImage2DMultisample(
+            target,
+            samples,
+            internal_format,
+            width,
+            height,
+            fixed_sample_locations
+        );
+    }
+
     unsafe fn compressed_tex_image_2d(
         &self,
         target: u32,

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -1915,6 +1915,18 @@ impl HasContext for Context {
         }
     }
 
+    unsafe fn tex_image_2d_multisample(
+        &self,
+        target: u32,
+        samples: i32,
+        internal_format: u32,
+        width: i32,
+        height: i32,
+        fixed_sample_locations: bool
+    ) {
+        unimplemented!()
+    }
+
     unsafe fn compressed_tex_image_2d(
         &self,
         target: u32,


### PR DESCRIPTION
Added glTexImage2DMultisample. I couldn't figure out how to implement it for WebGL, so I left it unimplemented.