### PR TITLE
add support for compressed_tex_sub_image_2d

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,11 @@ pub enum PixelUnpackData<'a> {
     Slice(&'a [u8]),
 }
 
+pub enum CompressedPixelUnpackData<'a> {
+    BufferRange(core::ops::Range<u32>),
+    Slice(&'a [u8]),
+}
+
 pub trait HasContext {
     type Shader: Copy + Clone + Debug + Eq + Hash + Ord + PartialEq + PartialOrd;
     type Program: Copy + Clone + Debug + Eq + Hash + Ord + PartialEq + PartialOrd;
@@ -747,6 +752,18 @@ pub trait HasContext {
         format: u32,
         ty: u32,
         pixels: PixelUnpackData,
+    );
+
+    unsafe fn compressed_tex_sub_image_2d(
+        &self,
+        target: u32,
+        level: i32,
+        x_offset: i32,
+        y_offset: i32,
+        width: i32,
+        height: i32,
+        format: u32,
+        pixels: CompressedPixelUnpackData,
     );
 
     unsafe fn tex_sub_image_3d(

--- a/src/native.rs
+++ b/src/native.rs
@@ -1659,6 +1659,33 @@ impl HasContext for Context {
         );
     }
 
+    unsafe fn compressed_tex_sub_image_2d(
+        &self,
+        target: u32,
+        level: i32,
+        x_offset: i32,
+        y_offset: i32,
+        width: i32,
+        height: i32,
+        format: u32,
+        pixels: CompressedPixelUnpackData,
+    ) {
+        let gl = &self.raw;
+        let (data, image_size) = match pixels {
+            CompressedPixelUnpackData::BufferRange(ref range) => (
+                range.start as *const std::ffi::c_void,
+                (range.end - range.start) as i32,
+            ),
+            CompressedPixelUnpackData::Slice(data) => {
+                (data.as_ptr() as *const std::ffi::c_void, data.len() as i32)
+            }
+        };
+
+        gl.CompressedTexSubImage2D(
+            target, level, x_offset, y_offset, width, height, format, image_size, data,
+        );
+    }
+
     unsafe fn tex_sub_image_3d(
         &self,
         target: u32,

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -2631,6 +2631,52 @@ impl HasContext for Context {
         }
     }
 
+    unsafe fn compressed_tex_sub_image_2d(
+        &self,
+        target: u32,
+        level: i32,
+        x_offset: i32,
+        y_offset: i32,
+        width: i32,
+        height: i32,
+        format: u32,
+        pixels: CompressedPixelUnpackData,
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => match pixels {
+                CompressedPixelUnpackData::BufferRange(_) => {
+                    panic!("Sub image 2D pixel buffer range is not supported");
+                }
+                CompressedPixelUnpackData::Slice(data) => {
+                    let data = texture_data_view(BYTE, data);
+                    gl.compressed_tex_sub_image_2d_with_array_buffer_view(
+                        target, level, x_offset, y_offset, width, height, format, &data,
+                    )
+                }
+            },
+            RawRenderingContext::WebGl2(ref gl) => match pixels {
+                CompressedPixelUnpackData::BufferRange(range) => gl
+                    .compressed_tex_sub_image_2d_with_i32_and_i32(
+                        target,
+                        level,
+                        x_offset,
+                        y_offset,
+                        width,
+                        height,
+                        format,
+                        (range.end - range.start) as i32,
+                        range.start as i32,
+                    ),
+                CompressedPixelUnpackData::Slice(data) => {
+                    let data = texture_data_view(BYTE, data);
+                    gl.compressed_tex_sub_image_2d_with_array_buffer_view(
+                        target, level, x_offset, y_offset, width, height, format, &data,
+                    )
+                }
+            },
+        }
+    }
+
     unsafe fn tex_sub_image_3d(
         &self,
         target: u32,


### PR DESCRIPTION
Current support for compressed texture is incomplete, because of missing `compressed_tex_sub_image_2d` method. This PR adds that. Due to a slight difference from non-compressed version, a new `PixelUnpackData`-like enum needed to be created, as the information about the data length must be provided.