### PR TITLE
expose webgl extensions through parameter api

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,9 @@ use core::fmt::Debug;
 use core::hash::Hash;
 use std::collections::HashSet;
 
+mod version;
+pub use version::Version;
+
 #[cfg(not(target_arch = "wasm32"))]
 mod native;
 #[cfg(not(target_arch = "wasm32"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@ use core::hash::Hash;
 use std::collections::HashSet;
 
 mod version;
-pub use version::Version;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod native;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 
 use core::fmt::Debug;
 use core::hash::Hash;
+use std::collections::HashSet;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod native;
@@ -89,6 +90,8 @@ pub trait HasContext {
     type Query: Copy + Clone + Debug + Eq + Hash + Ord + PartialEq + PartialOrd;
     type TransformFeedback: Copy + Clone + Debug + Eq + Hash + Ord + PartialEq + PartialOrd;
     type UniformLocation: Clone + Debug;
+
+    fn get_supported_extensions(&self) -> HashSet<String>;
 
     fn supports_debug(&self) -> bool;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ pub trait HasContext {
     type TransformFeedback: Copy + Clone + Debug + Eq + Hash + Ord + PartialEq + PartialOrd;
     type UniformLocation: Clone + Debug;
 
-    fn get_supported_extensions(&self) -> HashSet<String>;
+    fn supported_extensions(&self) -> &HashSet<String>;
 
     fn supports_debug(&self) -> bool;
 

--- a/src/native.rs
+++ b/src/native.rs
@@ -47,6 +47,14 @@ impl Context {
             context.extensions.insert(extension_name);
         }
 
+        // Fallback
+        context.extensions.extend(
+            context
+                .get_parameter_string(EXTENSIONS)
+                .split(' ')
+                .map(|s| s.to_string()),
+        );
+
         // After the extensions are known, we can populate constants (including
         // constants that depend on extensions being enabled)
         context.constants.max_label_length = if context.supports_debug() {
@@ -78,6 +86,10 @@ impl HasContext for Context {
     type Query = native_gl::GLuint;
     type UniformLocation = native_gl::GLuint;
     type TransformFeedback = native_gl::GLuint;
+
+    fn get_supported_extensions(&self) -> HashSet<String> {
+        self.extensions.clone()
+    }
 
     fn supports_debug(&self) -> bool {
         self.extensions.contains("GL_KHR_debug")
@@ -1138,7 +1150,7 @@ impl HasContext for Context {
         internal_format: i32,
         width: i32,
         height: i32,
-        fixed_sample_locations: bool
+        fixed_sample_locations: bool,
     ) {
         let gl = &self.raw;
         gl.TexImage2DMultisample(
@@ -1147,7 +1159,7 @@ impl HasContext for Context {
             internal_format as u32,
             width,
             height,
-            if fixed_sample_locations { 1 } else { 0 }
+            if fixed_sample_locations { 1 } else { 0 },
         );
     }
 

--- a/src/native.rs
+++ b/src/native.rs
@@ -94,8 +94,8 @@ impl HasContext for Context {
     type UniformLocation = native_gl::GLuint;
     type TransformFeedback = native_gl::GLuint;
 
-    fn get_supported_extensions(&self) -> HashSet<String> {
-        self.extensions.clone()
+    fn supported_extensions(&self) -> &HashSet<String> {
+        &self.extensions
     }
 
     fn supports_debug(&self) -> bool {

--- a/src/native.rs
+++ b/src/native.rs
@@ -4,6 +4,7 @@ use std::collections::HashSet;
 use std::ffi::CString;
 
 use crate::gl46 as native_gl;
+use crate::version::Version;
 
 #[derive(Default)]
 struct Constants {

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,6 +1,6 @@
 /// A version number for a specific component of an OpenGL implementation
 #[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
-pub struct Version {
+pub(crate) struct Version {
     pub major: u32,
     pub minor: u32,
     pub is_embedded: bool,

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,216 @@
+/// A version number for a specific component of an OpenGL implementation
+#[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Version {
+    pub major: u32,
+    pub minor: u32,
+    pub is_embedded: bool,
+    pub revision: Option<u32>,
+    pub vendor_info: String,
+}
+
+impl Version {
+    /// Create a new OpenGL version number
+    pub fn new(major: u32, minor: u32, revision: Option<u32>, vendor_info: String) -> Self {
+        Version {
+            major: major,
+            minor: minor,
+            is_embedded: false,
+            revision: revision,
+            vendor_info,
+        }
+    }
+    /// Create a new OpenGL ES version number
+    pub fn new_embedded(major: u32, minor: u32, vendor_info: String) -> Self {
+        Version {
+            major,
+            minor,
+            is_embedded: true,
+            revision: None,
+            vendor_info,
+        }
+    }
+
+    /// Get a tuple of (major, minor) versions
+    pub fn tuple(&self) -> (u32, u32) {
+        (self.major, self.minor)
+    }
+
+    /// According to the OpenGL specification, the version information is
+    /// expected to follow the following syntax:
+    ///
+    /// ~~~bnf
+    /// <major>       ::= <number>
+    /// <minor>       ::= <number>
+    /// <revision>    ::= <number>
+    /// <vendor-info> ::= <string>
+    /// <release>     ::= <major> "." <minor> ["." <release>]
+    /// <version>     ::= <release> [" " <vendor-info>]
+    /// ~~~
+    ///
+    /// Note that this function is intentionally lenient in regards to parsing,
+    /// and will try to recover at least the first two version numbers without
+    /// resulting in an `Err`.
+    /// # Notes
+    /// `WebGL 2` version returned as `OpenGL ES 3.0`
+    pub fn parse(mut src: &str) -> Result<Version, &str> {
+        let webgl_sig = "WebGL ";
+        // According to the WebGL specification
+        // VERSION	WebGL<space>1.0<space><vendor-specific information>
+        // SHADING_LANGUAGE_VERSION	WebGL<space>GLSL<space>ES<space>1.0<space><vendor-specific information>
+        let is_webgl = src.starts_with(webgl_sig);
+        let is_es = if is_webgl {
+            let pos = src.rfind(webgl_sig).unwrap_or(0);
+            src = &src[pos + webgl_sig.len()..];
+            true
+        } else {
+            let es_sig = " ES ";
+            match src.rfind(es_sig) {
+                Some(pos) => {
+                    src = &src[pos + es_sig.len()..];
+                    true
+                }
+                None => false,
+            }
+        };
+
+        let glsl_es_sig = "GLSL ES ";
+        let is_glsl = match src.find(glsl_es_sig) {
+            Some(pos) => {
+                src = &src[pos + glsl_es_sig.len()..];
+                true
+            }
+            None => false,
+        };
+
+        let (version, vendor_info) = match src.find(' ') {
+            Some(i) => (&src[..i], src[i + 1..].to_string()),
+            None => (src, String::new()),
+        };
+
+        // TODO: make this even more lenient so that we can also accept
+        // `<major> "." <minor> [<???>]`
+        let mut it = version.split('.');
+        let major = it.next().and_then(|s| s.parse().ok());
+        let minor = it.next().and_then(|s| {
+            let trimmed = if s.starts_with('0') {
+                "0"
+            } else {
+                s.trim_end_matches('0')
+            };
+            trimmed.parse().ok()
+        });
+        let revision = if is_webgl {
+            None
+        } else {
+            it.next().and_then(|s| s.parse().ok())
+        };
+
+        match (major, minor, revision) {
+            (Some(major), Some(minor), revision) => Ok(Version {
+                // Return WebGL 2.0 version as OpenGL ES 3.0
+                major: if is_webgl && !is_glsl {
+                    major + 1
+                } else {
+                    major
+                },
+                minor,
+                is_embedded: is_es,
+                revision,
+                vendor_info,
+            }),
+            (_, _, _) => Err(src),
+        }
+    }
+}
+
+impl std::fmt::Debug for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match (
+            self.major,
+            self.minor,
+            self.revision,
+            self.vendor_info.as_str(),
+        ) {
+            (major, minor, Some(revision), "") => write!(f, "{}.{}.{}", major, minor, revision),
+            (major, minor, None, "") => write!(f, "{}.{}", major, minor),
+            (major, minor, Some(revision), vendor_info) => {
+                write!(f, "{}.{}.{}, {}", major, minor, revision, vendor_info)
+            }
+            (major, minor, None, vendor_info) => write!(f, "{}.{}, {}", major, minor, vendor_info),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Version;
+
+    #[test]
+    fn test_version_parse() {
+        assert_eq!(Version::parse("1"), Err("1"));
+        assert_eq!(Version::parse("1."), Err("1."));
+        assert_eq!(Version::parse("1 h3l1o. W0rld"), Err("1 h3l1o. W0rld"));
+        assert_eq!(Version::parse("1. h3l1o. W0rld"), Err("1. h3l1o. W0rld"));
+        assert_eq!(
+            Version::parse("1.2.3"),
+            Ok(Version::new(1, 2, Some(3), String::new()))
+        );
+        assert_eq!(
+            Version::parse("1.2"),
+            Ok(Version::new(1, 2, None, String::new()))
+        );
+        assert_eq!(
+            Version::parse("1.2 h3l1o. W0rld"),
+            Ok(Version::new(1, 2, None, "h3l1o. W0rld".to_string()))
+        );
+        assert_eq!(
+            Version::parse("1.2.h3l1o. W0rld"),
+            Ok(Version::new(1, 2, None, "W0rld".to_string()))
+        );
+        assert_eq!(
+            Version::parse("1.2. h3l1o. W0rld"),
+            Ok(Version::new(1, 2, None, "h3l1o. W0rld".to_string()))
+        );
+        assert_eq!(
+            Version::parse("1.2.3.h3l1o. W0rld"),
+            Ok(Version::new(1, 2, Some(3), "W0rld".to_string()))
+        );
+        assert_eq!(
+            Version::parse("1.2.3 h3l1o. W0rld"),
+            Ok(Version::new(1, 2, Some(3), "h3l1o. W0rld".to_string()))
+        );
+        assert_eq!(
+            Version::parse("OpenGL ES 3.1"),
+            Ok(Version::new_embedded(3, 1, String::new()))
+        );
+        assert_eq!(
+            Version::parse("OpenGL ES 2.0 Google Nexus"),
+            Ok(Version::new_embedded(2, 0, "Google Nexus".to_string()))
+        );
+        assert_eq!(
+            Version::parse("GLSL ES 1.1"),
+            Ok(Version::new_embedded(1, 1, String::new()))
+        );
+        assert_eq!(
+            Version::parse("OpenGL ES GLSL ES 3.20"),
+            Ok(Version::new_embedded(3, 2, String::new()))
+        );
+        assert_eq!(
+            // WebGL 2.0 should parse as OpenGL ES 3.0
+            Version::parse("WebGL 2.0 (OpenGL ES 3.0 Chromium)"),
+            Ok(Version::new_embedded(
+                3,
+                0,
+                "(OpenGL ES 3.0 Chromium)".to_string()
+            ))
+        );
+        assert_eq!(
+            Version::parse("WebGL GLSL ES 3.00 (OpenGL ES GLSL ES 3.0 Chromium)"),
+            Ok(Version::new_embedded(
+                3,
+                0,
+                "(OpenGL ES GLSL ES 3.0 Chromium)".to_string()
+            ))
+        );
+    }
+}

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -1544,7 +1544,12 @@ impl HasContext for Context {
     unsafe fn get_parameter_i32(&self, parameter: u32) -> i32 {
         match self.raw {
             RawRenderingContext::WebGl1(ref gl) => gl.get_parameter(parameter),
-            RawRenderingContext::WebGl2(ref gl) => gl.get_parameter(parameter),
+            RawRenderingContext::WebGl2(ref gl) => {
+                if parameter == NUM_EXTENSIONS {
+                    return gl.get_supported_extensions().unwrap().length() as i32;
+                }
+                gl.get_parameter(parameter)
+            }
         }
         .unwrap()
         .as_f64()
@@ -1615,16 +1620,37 @@ impl HasContext for Context {
             RawRenderingContext::WebGl1(ref _gl) => {
                 panic!("Get parameter indexed is not supported")
             }
-            RawRenderingContext::WebGl2(ref gl) => gl.get_indexed_parameter(parameter, index),
+            RawRenderingContext::WebGl2(ref gl) => {
+                if parameter == EXTENSIONS {
+                    gl.get_supported_extensions()
+                        .unwrap()
+                        .get(index)
+                        .as_string()
+                        .unwrap_or_else(|| String::from(""))
+                } else {
+                    gl.get_indexed_parameter(parameter, index)
+                        .unwrap()
+                        .as_string()
+                        // Errors will be caught by the browser or through `get_error`
+                        // so return a default instead
+                        .unwrap_or_else(|| String::from(""))
+                }
+            }
         }
-        .unwrap()
-        .as_string()
-        // Errors will be caught by the browser or through `get_error`
-        // so return a default instead
-        .unwrap_or_else(|| String::from(""))
     }
 
     unsafe fn get_parameter_string(&self, parameter: u32) -> String {
+        if parameter == EXTENSIONS {
+            return match self.raw {
+                RawRenderingContext::WebGl1(ref gl) => gl.get_supported_extensions(),
+                RawRenderingContext::WebGl2(ref gl) => gl.get_supported_extensions(),
+            }
+            .unwrap()
+            .join(" ")
+            .as_string()
+            .unwrap();
+        }
+
         match self.raw {
             RawRenderingContext::WebGl1(ref gl) => gl.get_parameter(parameter),
             RawRenderingContext::WebGl2(ref gl) => gl.get_parameter(parameter),
@@ -1909,7 +1935,7 @@ impl HasContext for Context {
         internal_format: i32,
         width: i32,
         height: i32,
-        fixed_sample_locations: bool
+        fixed_sample_locations: bool,
     ) {
         panic!("Tex image 2D multisample is not supported");
     }

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -442,7 +442,10 @@ impl HasContext for Context {
             RawRenderingContext::WebGl2(ref gl) => gl.get_supported_extensions(),
         }
         .unwrap();
-        extensions_array.iter().map(|val| val.as_string()).collect()
+        extensions_array
+            .iter()
+            .map(|val| val.as_string().unwrap())
+            .collect()
     }
 
     fn supports_debug(&self) -> bool {


### PR DESCRIPTION
Currently it is impossible to query for webgl extensions, due to it using specialized unexposed api for retreiving the list. This PR exposes the list with desktop gl api by intercepting parameter calls and implementing them using the web-specific api under the hood.