### PR TITLE
Expand the example to upload vertices

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,4 +90,5 @@ features = [
 [workspace]
 members = [
   "examples/hello",
+  "examples/howto",
 ]

--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -71,17 +71,21 @@ fn main() {
         let program = gl.create_program().expect("Cannot create program");
 
         let (vertex_shader_source, fragment_shader_source) = (
-            r#"in vec2 in_position;
-            out vec2 position;
+            r#"const vec2 verts[3] = vec2[3](
+                vec2(0.5f, 1.0f),
+                vec2(0.0f, 0.0f),
+                vec2(1.0f, 0.0f)
+            );
+            out vec2 vert;
             void main() {
-                position = in_position;
-                gl_Position = vec4(in_position - 0.5, 0.0, 1.0);
+                vert = verts[gl_VertexID];
+                gl_Position = vec4(vert - 0.5, 0.0, 1.0);
             }"#,
             r#"precision mediump float;
-            in vec2 position;
+            in vec2 vert;
             out vec4 color;
             void main() {
-                color = vec4(position, 0.5, 1.0);
+                color = vec4(vert, 0.5, 1.0);
             }"#,
         );
 
@@ -116,23 +120,6 @@ fn main() {
         }
 
         gl.use_program(Some(program));
-
-        // This is a flat array of f32s that are to be interpreted as vec2s.
-        let triangle_vertices = [0.5f32, 1.0f32, 0.0f32, 0.0f32, 1.0f32, 0.0f32];
-        let triangle_vertices_u8: &[u8] = core::slice::from_raw_parts(
-            triangle_vertices.as_ptr() as *const u8,
-            triangle_vertices.len() * core::mem::size_of::<f32>(),
-        );
-        let vbo = gl.create_buffer().unwrap();
-        gl.bind_buffer(glow::ARRAY_BUFFER, Some(vbo));
-        gl.buffer_data_u8_slice(glow::ARRAY_BUFFER, triangle_vertices_u8, glow::STATIC_DRAW);
-
-        // We now construct a vertex array to describe the format of the input buffer
-        let vao = gl.create_vertex_array().unwrap();
-        gl.bind_vertex_array(Some(vao));
-        gl.enable_vertex_attrib_array(0);
-        gl.vertex_attrib_pointer_f32(0, 2, glow::FLOAT, false, 8, 0);
-
         gl.clear_color(0.1, 0.2, 0.3, 1.0);
 
         // We handle events differently between targets

--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -60,7 +60,7 @@ fn main() {
             let gl =
                 glow::Context::from_loader_function(|s| video.gl_get_proc_address(s) as *const _);
             let event_loop = sdl.event_pump().unwrap();
-            (gl, "#version 410", window, event_loop, gl_context)
+            (gl, "#version 130", window, event_loop, gl_context)
         };
 
         let vertex_array = gl
@@ -71,21 +71,17 @@ fn main() {
         let program = gl.create_program().expect("Cannot create program");
 
         let (vertex_shader_source, fragment_shader_source) = (
-            r#"const vec2 verts[3] = vec2[3](
-                vec2(0.5f, 1.0f),
-                vec2(0.0f, 0.0f),
-                vec2(1.0f, 0.0f)
-            );
-            out vec2 vert;
+            r#"in vec2 in_position;
+            out vec2 position;
             void main() {
-                vert = verts[gl_VertexID];
-                gl_Position = vec4(vert - 0.5, 0.0, 1.0);
+                position = in_position;
+                gl_Position = vec4(in_position - 0.5, 0.0, 1.0);
             }"#,
             r#"precision mediump float;
-            in vec2 vert;
+            in vec2 position;
             out vec4 color;
             void main() {
-                color = vec4(vert, 0.5, 1.0);
+                color = vec4(position, 0.5, 1.0);
             }"#,
         );
 
@@ -120,6 +116,23 @@ fn main() {
         }
 
         gl.use_program(Some(program));
+
+        // This is a flat array of f32s that are to be interpreted as vec2s.
+        let triangle_vertices = [0.5f32, 1.0f32, 0.0f32, 0.0f32, 1.0f32, 0.0f32];
+        let triangle_vertices_u8: &[u8] = core::slice::from_raw_parts(
+            triangle_vertices.as_ptr() as *const u8,
+            triangle_vertices.len() * core::mem::size_of::<f32>(),
+        );
+        let vbo = gl.create_buffer().unwrap();
+        gl.bind_buffer(glow::ARRAY_BUFFER, Some(vbo));
+        gl.buffer_data_u8_slice(glow::ARRAY_BUFFER, triangle_vertices_u8, glow::STATIC_DRAW);
+
+        // We now construct a vertex array to describe the format of the input buffer
+        let vao = gl.create_vertex_array().unwrap();
+        gl.bind_vertex_array(Some(vao));
+        gl.enable_vertex_attrib_array(0);
+        gl.vertex_attrib_pointer_f32(0, 2, glow::FLOAT, false, 8, 0);
+
         gl.clear_color(0.1, 0.2, 0.3, 1.0);
 
         // We handle events differently between targets

--- a/examples/howto/Cargo.toml
+++ b/examples/howto/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "howto"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+glow = { path = "../../" }
+sdl2 = { version = "0.34" }

--- a/examples/howto/README.md
+++ b/examples/howto/README.md
@@ -1,0 +1,9 @@
+# `howto` example
+
+This example is meant to showcase common actions within `glow`.
+
+# How to Build
+
+```shell
+cargo run
+```

--- a/examples/howto/src/main.rs
+++ b/examples/howto/src/main.rs
@@ -1,0 +1,147 @@
+use glow::*;
+
+fn main() {
+    unsafe {
+        // Create a context from a sdl2 window
+        let (gl, window, mut events_loop, _context) = create_sdl2_context();
+
+        // Create a shader program from source
+        let program = create_program(&gl, VERTEX_SHADER_SOURCE, FRAGMENT_SHADER_SOURCE);
+        gl.use_program(Some(program));
+
+        // Create a vertex buffer and vertex array object
+        let (vbo, vao) = create_vertex_buffer(&gl);
+
+        // Upload some uniforms
+        set_uniform(&gl, program, "blue", 0.8);
+
+        gl.clear_color(0.1, 0.2, 0.3, 1.0);
+
+        'render: loop {
+            {
+                for event in events_loop.poll_iter() {
+                    if let sdl2::event::Event::Quit { .. } = event {
+                        break 'render;
+                    }
+                }
+            }
+
+            gl.clear(glow::COLOR_BUFFER_BIT);
+            gl.draw_arrays(glow::TRIANGLES, 0, 3);
+            window.gl_swap_window();
+        }
+
+        // Clean up
+        gl.delete_program(program);
+        gl.delete_vertex_array(vao);
+        gl.delete_buffer(vbo)
+    }
+}
+
+unsafe fn create_sdl2_context() -> (
+    glow::Context,
+    sdl2::video::Window,
+    sdl2::EventPump,
+    sdl2::video::GLContext,
+) {
+    let sdl = sdl2::init().unwrap();
+    let video = sdl.video().unwrap();
+    let gl_attr = video.gl_attr();
+    gl_attr.set_context_profile(sdl2::video::GLProfile::Core);
+    gl_attr.set_context_version(3, 0);
+    let window = video
+        .window("Hello triangle!", 1024, 769)
+        .opengl()
+        .resizable()
+        .build()
+        .unwrap();
+    let gl_context = window.gl_create_context().unwrap();
+    let gl = glow::Context::from_loader_function(|s| video.gl_get_proc_address(s) as *const _);
+    let event_loop = sdl.event_pump().unwrap();
+
+    (gl, window, event_loop, gl_context)
+}
+
+unsafe fn create_program(
+    gl: &glow::Context,
+    vertex_shader_source: &str,
+    fragment_shader_source: &str,
+) -> NativeProgram {
+    let program = gl.create_program().expect("Cannot create program");
+
+    let shader_sources = [
+        (glow::VERTEX_SHADER, vertex_shader_source),
+        (glow::FRAGMENT_SHADER, fragment_shader_source),
+    ];
+
+    let mut shaders = Vec::with_capacity(shader_sources.len());
+
+    for (shader_type, shader_source) in shader_sources.iter() {
+        let shader = gl
+            .create_shader(*shader_type)
+            .expect("Cannot create shader");
+        gl.shader_source(shader, shader_source);
+        gl.compile_shader(shader);
+        if !gl.get_shader_compile_status(shader) {
+            panic!("{}", gl.get_shader_info_log(shader));
+        }
+        gl.attach_shader(program, shader);
+        shaders.push(shader);
+    }
+
+    gl.link_program(program);
+    if !gl.get_program_link_status(program) {
+        panic!("{}", gl.get_program_info_log(program));
+    }
+
+    for shader in shaders {
+        gl.detach_shader(program, shader);
+        gl.delete_shader(shader);
+    }
+
+    program
+}
+
+unsafe fn create_vertex_buffer(gl: &glow::Context) -> (NativeBuffer, NativeVertexArray) {
+    // This is a flat array of f32s that are to be interpreted as vec2s.
+    let triangle_vertices = [0.5f32, 1.0f32, 0.0f32, 0.0f32, 1.0f32, 0.0f32];
+    let triangle_vertices_u8: &[u8] = core::slice::from_raw_parts(
+        triangle_vertices.as_ptr() as *const u8,
+        triangle_vertices.len() * core::mem::size_of::<f32>(),
+    );
+
+    // We construct a buffer and upload the data
+    let vbo = gl.create_buffer().unwrap();
+    gl.bind_buffer(glow::ARRAY_BUFFER, Some(vbo));
+    gl.buffer_data_u8_slice(glow::ARRAY_BUFFER, triangle_vertices_u8, glow::STATIC_DRAW);
+
+    // We now construct a vertex array to describe the format of the input buffer
+    let vao = gl.create_vertex_array().unwrap();
+    gl.bind_vertex_array(Some(vao));
+    gl.enable_vertex_attrib_array(0);
+    gl.vertex_attrib_pointer_f32(0, 2, glow::FLOAT, false, 8, 0);
+
+    (vbo, vao)
+}
+
+unsafe fn set_uniform(gl: &glow::Context, program: NativeProgram, name: &str, value: f32) {
+    let uniform_location = gl.get_uniform_location(program, name);
+    // See also `uniform_n_i32`, `uniform_n_u32`, `uniform_matrix_4_f32_slice` etc.
+    gl.uniform_1_f32(uniform_location.as_ref(), value)
+}
+
+const VERTEX_SHADER_SOURCE: &str = r#"#version 130
+  in vec2 in_position;
+  out vec2 position;
+  void main() {
+    position = in_position;
+    gl_Position = vec4(in_position - 0.5, 0.0, 1.0);
+  }"#;
+const FRAGMENT_SHADER_SOURCE: &str = r#"#version 130
+  precision mediump float;
+  in vec2 position;
+  out vec4 color;
+  uniform float blue;
+  void main() {
+    color = vec4(position, blue, 1.0);
+  }"#;


### PR DESCRIPTION
This uploads data (positions) to opengl via a vertex buffer object
and vertex array object.  It uses unsafe transmutation code which
could be replaced by an external crate, but does it manually to
prevent dependency bloat (and to express exactly what is going on).

Further, the GLSL version number for SDL2 is downgraded to 130 so
as to run on the OpenGL3.0 requested from SDL2.