### PR TITLE
Add support for the `glGetActiveUniformBlock` family of functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -468,6 +468,27 @@ pub trait HasContext {
 
     unsafe fn get_parameter_string(&self, parameter: u32) -> String;
 
+    unsafe fn get_active_uniform_block_parameter_i32(
+        &self,
+        program: Self::Program,
+        uniform_block_index: u32,
+        parameter: u32,
+    ) -> i32;
+
+    unsafe fn get_active_uniform_block_parameter_i32_slice(
+        &self,
+        program: Self::Program,
+        uniform_block_index: u32,
+        parameter: u32,
+        out: &mut [i32]
+    );
+
+    unsafe fn get_active_uniform_block_name(
+        &self,
+        program: Self::Program,
+        uniform_block_index: u32,
+    ) -> String;
+
     unsafe fn get_uniform_location(
         &self,
         program: Self::Program,


### PR DESCRIPTION
Fixes #183.

## What is it?
This pull request adds support for the `glGetActiveUniformBlock` family of functions through the addition of three new functions to `HasContext`:
- `get_active_uniform_block_parameter_i32`, which retrieves a single signed integer parameter and is intended for use with the following `pname`s:
  - `GL_UNIFORM_BLOCK_BINDING`,
  - `GL_UNIFORM_BLOCK_DATA_SIZE`,
  - `GL_UNIFORM_BLOCK_ACTIVE_UNIFORMS`,
  - `GL_UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER`, and
  - `GL_UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER`.
- `get_active_uniform_block_parameter_i32_slice`, which retrieves a slice of signed integer parameters and is intended for use with the following `pname`:
  - `GL_UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES`.
- `get_active_uniform_block_name`, which retrieves the name of a uniform block, as a string.

## Potential Implementation Pitfalls
[In the WebGL backend](https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext/getActiveUniformBlockParameter), the integer data types returned by the `getActiveUniformBlockParameter` function are unsigned, rather than signed, as they are [in OpenGL](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveUniformBlock.xhtml). In my implementation I have decided to follow OpenGL, rather than WebGL, and have thus opted to implement functions with an `i32` return type, rather than with a `u32`.

When retrieving the name of an active uniform block in the native backend, this implementation will buffer `256` bytes on the stack and pass those as the receiving name buffer to OpenGL, as there doesn't seem to be a way to query for the length of the uniform block's name ahead of time.