### PR TITLE
Use read_pixels_with_opt_array_buffer_view

### DIFF
--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -3369,12 +3369,13 @@ impl HasContext for Context {
             }
             PixelPackData::Slice(slice) => Some(slice),
         };
+        let data = data.map(|bytes| texture_data_view(gltype, bytes));
         match self.raw {
             RawRenderingContext::WebGl1(ref gl) => gl
-                .read_pixels_with_opt_u8_array(x, y, width, height, format, gltype, data)
+                .read_pixels_with_opt_array_buffer_view(x, y, width, height, format, gltype, data.as_ref())
                 .unwrap(),
             RawRenderingContext::WebGl2(ref gl) => gl
-                .read_pixels_with_opt_u8_array(x, y, width, height, format, gltype, data)
+                .read_pixels_with_opt_array_buffer_view(x, y, width, height, format, gltype, data.as_ref())
                 .unwrap(),
         }
     }


### PR DESCRIPTION
In my application I use `RG_INTEGER` / `UNSIGNED_INT` texture format and `read_pixels` (in chrome) throws:
```
WebGL: INVALID_OPERATION: readPixels: type UNSIGNED_INT but ArrayBufferView not Uint32Array
```

The solution is to create proper ArrayBufferView using `texture_data_view` and call `read_pixels_with_opt_array_buffer_view`
