### PR TITLE
support wasm32-unknown-emscripten

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,17 +11,17 @@ use std::collections::HashSet;
 
 mod version;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
 mod native;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
 pub use native::*;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
 mod gl46;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
 #[path = "web_sys.rs"]
 mod web;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
 pub use web::*;
 
 pub type Shader = <Context as HasContext>::Shader;


### PR DESCRIPTION
Related to #189
To support `wasm32-unknown-emscripten` no need to do anything special like c api. It just works as is, because emscripten emulates OpenGL ES 3.0, so just disabling web path for it works fine (tested on vange-rs project)