### PR TITLE
Expose `Version` and add `Context::version`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ use core::hash::Hash;
 use std::collections::HashSet;
 
 mod version;
+pub use version::Version;
 
 #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
 mod native;
@@ -96,6 +97,8 @@ pub trait HasContext {
     fn supported_extensions(&self) -> &HashSet<String>;
 
     fn supports_debug(&self) -> bool;
+
+    fn version(&self) -> &Version;
 
     unsafe fn create_framebuffer(&self) -> Result<Self::Framebuffer, String>;
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,6 +1,6 @@
 /// A version number for a specific component of an OpenGL implementation
 #[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
-pub(crate) struct Version {
+pub struct Version {
     pub major: u32,
     pub minor: u32,
     pub is_embedded: bool,
@@ -10,7 +10,7 @@ pub(crate) struct Version {
 
 impl Version {
     /// Create a new OpenGL version number
-    pub fn new(major: u32, minor: u32, revision: Option<u32>, vendor_info: String) -> Self {
+    pub(crate) fn new(major: u32, minor: u32, revision: Option<u32>, vendor_info: String) -> Self {
         Version {
             major: major,
             minor: minor,
@@ -20,7 +20,7 @@ impl Version {
         }
     }
     /// Create a new OpenGL ES version number
-    pub fn new_embedded(major: u32, minor: u32, vendor_info: String) -> Self {
+    pub(crate) fn new_embedded(major: u32, minor: u32, vendor_info: String) -> Self {
         Version {
             major,
             minor,
@@ -47,7 +47,7 @@ impl Version {
     /// resulting in an `Err`.
     /// # Notes
     /// `WebGL 2` version returned as `OpenGL ES 3.0`
-    pub fn parse(mut src: &str) -> Result<Version, &str> {
+    pub(crate) fn parse(mut src: &str) -> Result<Version, &str> {
         let webgl_sig = "WebGL ";
         // According to the WebGL specification
         // VERSION	WebGL<space>1.0<space><vendor-specific information>


### PR DESCRIPTION
This PR aims to expose the `Version` struct through a new `Context::version`.

Since parsing of `glow::VERSION` is already done internally, it would be great if this was exposed so that no further parsing would be needed (e.g to check if the current context supports instancing, etc).