### PR TITLE
Fix segfault if there is no current GL context active

### DIFF
--- a/src/native.rs
+++ b/src/native.rs
@@ -33,6 +33,11 @@ impl Context {
 
         // Retrieve and parse `GL_VERSION`
         let raw_string = raw.GetString(VERSION);
+
+        if raw_string.is_null() {
+            panic!("Reading GL_VERSION failed. Make sure there is a valid GL context currently active.")
+        }
+
         let raw_version = std::ffi::CStr::from_ptr(raw_string as *const native_gl::GLchar)
             .to_str()
             .unwrap()


### PR DESCRIPTION
This PR adds a null-check on the fetched GL_VERSION string in the `Context::from_loader_function` method to prevent it from segfaulting when there is no current GL context (this PR makes it panic with an explicit error message instead).

I stumbled across this segfault while working on a project where the GL context creation had silently failed, however this can be more easily reproduced by editing the `howto` example and removing the [`window.gl_create_context()` call](https://github.com/grovesNL/glow/blob/b8952494641beb51bc05f874e80dac51c09ff7ad/examples/howto/src/main.rs#L58).

I wrote the error message as how it could have helped past me in debugging, but feel free to make changes to it if there is more appropriate, as I am no expert on the subject. :slightly_smiling_face: 