### PR TITLE
Added log as an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ targets = [
 name = "glow"
 path = "src/lib.rs"
 
+[dependencies]
+log = { version = "0.4.16", optional = true }
+
 [features]
 debug_trace_calls = []
 debug_automatic_glGetError = []


### PR DESCRIPTION
Simply adds [log](https://crates.io/crates/log) as an optional dependency to complement #203