### PR TITLE
add parallel shader compile extensions

### DIFF
--- a/src/gl46.rs
+++ b/src/gl46.rs
@@ -18,6 +18,7 @@
 //! * `GL_ARB_framebuffer_object`
 //! * `GL_ARB_framebuffer_sRGB`
 //! * `GL_ARB_instanced_arrays`
+//! * `GL_ARB_parallel_shader_compile`
 //! * `GL_ARB_program_interface_query`
 //! * `GL_ARB_sampler_objects`
 //! * `GL_ARB_sync`
@@ -30,6 +31,7 @@
 //! * `GL_EXT_draw_buffers2`
 //! * `GL_EXT_texture_filter_anisotropic`
 //! * `GL_KHR_debug`
+//! * `GL_KHR_parallel_shader_compile`
 //! * `GL_NV_copy_buffer`
 //!
 //! Supported Features:
@@ -4943,6 +4945,8 @@ pub mod struct_commands {
             self.MapBufferRange_load_with_dyn(get_proc_address);
             self.MapNamedBuffer_load_with_dyn(get_proc_address);
             self.MapNamedBufferRange_load_with_dyn(get_proc_address);
+            self.MaxShaderCompilerThreadsARB_load_with_dyn(get_proc_address);
+            self.MaxShaderCompilerThreadsKHR_load_with_dyn(get_proc_address);
             self.MemoryBarrier_load_with_dyn(get_proc_address);
             self.MemoryBarrierByRegion_load_with_dyn(get_proc_address);
             self.MinSampleShading_load_with_dyn(get_proc_address);
@@ -21120,6 +21124,76 @@ pub mod struct_commands {
         pub fn MapNamedBufferRange_is_loaded(&self) -> bool {
             !self.glMapNamedBufferRange_p.load(RELAX).is_null()
         }
+        /// [MaxShaderCompilerThreadsARB](http://docs.gl/gl4/MaxShaderCompilerThreadsARB)(count)
+        #[cfg_attr(feature = "inline", inline)]
+        #[cfg_attr(feature = "inline_always", inline(always))]
+        pub unsafe fn MaxShaderCompilerThreadsARB(&self, count: GLuint) {
+            #[cfg(all(debug_assertions, feature = "debug_trace_calls"))]
+            {
+                trace!("calling gl.MaxShaderCompilerThreadsARB({:?});", count);
+            }
+            let out = call_atomic_ptr_1arg(
+                "MaxShaderCompilerThreadsARB",
+                &self.glMaxShaderCompilerThreadsARB_p,
+                count
+            );
+            #[cfg(all(debug_assertions, feature = "debug_automatic_glGetError"))]
+            {
+                self.automatic_glGetError("glMaxShaderCompilerThreadsARB");
+            }
+            out
+        }
+        #[doc(hidden)]
+        pub unsafe fn MaxShaderCompilerThreadsARB_load_with_dyn(
+            &self,
+            get_proc_address: &mut dyn FnMut(*const c_char) -> *mut c_void,
+        ) -> bool {
+            load_dyn_name_atomic_ptr(
+                get_proc_address,
+                b"glMaxShaderCompilerThreadsARB\0",
+                &self.glMaxShaderCompilerThreadsARB_p,
+            )
+        }
+        #[inline]
+        #[doc(hidden)]
+        pub fn MaxShaderCompilerThreadsARB_is_loaded(&self) -> bool {
+            !self.glMaxShaderCompilerThreadsARB_p.load(RELAX).is_null()
+        }
+        /// [MaxShaderCompilerThreadsKHR](http://docs.gl/gl4/MaxShaderCompilerThreadsKHR)(count)
+        #[cfg_attr(feature = "inline", inline)]
+        #[cfg_attr(feature = "inline_always", inline(always))]
+        pub unsafe fn MaxShaderCompilerThreadsKHR(&self, count: GLuint) {
+            #[cfg(all(debug_assertions, feature = "debug_trace_calls"))]
+            {
+                trace!("calling gl.MaxShaderCompilerThreadsKHR({:?});", count);
+            }
+            let out = call_atomic_ptr_1arg(
+                "glMaxShaderCompilerThreadsKHR",
+                &self.glMaxShaderCompilerThreadsKHR_p,
+                count
+            );
+            #[cfg(all(debug_assertions, feature = "debug_automatic_glGetError"))]
+            {
+                self.automatic_glGetError("glMaxShaderCompilerThreadsKHR");
+            }
+            out
+        }
+        #[doc(hidden)]
+        pub unsafe fn MaxShaderCompilerThreadsKHR_load_with_dyn(
+            &self,
+            get_proc_address: &mut dyn FnMut(*const c_char) -> *mut c_void,
+        ) -> bool {
+            load_dyn_name_atomic_ptr(
+                get_proc_address,
+                b"glMaxShaderCompilerThreadsKHR\0",
+                &self.glMaxShaderCompilerThreadsKHR_p,
+            )
+        }
+        #[inline]
+        #[doc(hidden)]
+        pub fn MaxShaderCompilerThreadsKHR_is_loaded(&self) -> bool {
+            !self.glMaxShaderCompilerThreadsKHR_p.load(RELAX).is_null()
+        }
         /// [glMemoryBarrier](http://docs.gl/gl4/glMemoryBarrier)(barriers)
         /// * `barriers` group: MemoryBarrierMask
         #[cfg_attr(feature = "inline", inline)]
@@ -35574,6 +35648,8 @@ pub mod struct_commands {
         glMapBufferRange_p: APcv,
         glMapNamedBuffer_p: APcv,
         glMapNamedBufferRange_p: APcv,
+        glMaxShaderCompilerThreadsARB_p: APcv,
+        glMaxShaderCompilerThreadsKHR_p: APcv,
         glMemoryBarrier_p: APcv,
         glMemoryBarrierByRegion_p: APcv,
         glMinSampleShading_p: APcv,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,8 @@ pub trait HasContext {
 
     unsafe fn compile_shader(&self, shader: Self::Shader);
 
+    unsafe fn get_shader_completion_status(&self, shader: Self::Shader) -> bool;
+
     unsafe fn get_shader_compile_status(&self, shader: Self::Shader) -> bool;
 
     unsafe fn get_shader_info_log(&self, shader: Self::Shader) -> String;
@@ -152,6 +154,8 @@ pub trait HasContext {
     unsafe fn detach_shader(&self, program: Self::Program, shader: Self::Shader);
 
     unsafe fn link_program(&self, program: Self::Program);
+
+    unsafe fn get_program_completion_status(&self, program: Self::Program) -> bool;
 
     unsafe fn get_program_link_status(&self, program: Self::Program) -> bool;
 
@@ -1233,6 +1237,8 @@ pub trait HasContext {
         access: u32,
         format: u32,
     );
+
+    unsafe fn max_shader_compiler_threads(&self, count: u32);
 }
 
 pub const ACTIVE_ATOMIC_COUNTER_BUFFERS: u32 = 0x92D9;
@@ -1544,6 +1550,8 @@ pub const COMPARE_REF_TO_TEXTURE: u32 = 0x884E;
 pub const COMPATIBLE_SUBROUTINES: u32 = 0x8E4B;
 
 pub const COMPILE_STATUS: u32 = 0x8B81;
+
+pub const COMPLETION_STATUS: u32 = 0x91B1;
 
 pub const COMPRESSED_R11_EAC: u32 = 0x9270;
 
@@ -2580,6 +2588,8 @@ pub const MAX_SAMPLES: u32 = 0x8D57;
 pub const MAX_SAMPLE_MASK_WORDS: u32 = 0x8E59;
 
 pub const MAX_SERVER_WAIT_TIMEOUT: u32 = 0x9111;
+
+pub const MAX_SHADER_COMPILER_THREADS: u32 = 0x91B0;
 
 pub const MAX_SHADER_STORAGE_BLOCK_SIZE: u32 = 0x90DE;
 

--- a/src/native.rs
+++ b/src/native.rs
@@ -260,6 +260,13 @@ impl HasContext for Context {
         gl.CompileShader(shader.0.get());
     }
 
+    unsafe fn get_shader_completion_status(&self, shader: Self::Shader) -> bool {
+        let gl = &self.raw;
+        let mut status = 0;
+        gl.GetShaderiv(shader.0.get(), COMPLETION_STATUS, &mut status);
+        1 == status
+    }
+
     unsafe fn get_shader_compile_status(&self, shader: Self::Shader) -> bool {
         let gl = &self.raw;
         let mut status = 0;
@@ -336,6 +343,13 @@ impl HasContext for Context {
     unsafe fn link_program(&self, program: Self::Program) {
         let gl = &self.raw;
         gl.LinkProgram(program.0.get());
+    }
+
+    unsafe fn get_program_completion_status(&self, program: Self::Program) -> bool {
+        let gl = &self.raw;
+        let mut status = 0;
+        gl.GetProgramiv(program.0.get(), COMPLETION_STATUS, &mut status);
+        1 == status
     }
 
     unsafe fn get_program_link_status(&self, program: Self::Program) -> bool {
@@ -2961,6 +2975,15 @@ impl HasContext for Context {
             name
         } else {
             String::from("")
+        }
+    }
+
+    unsafe fn max_shader_compiler_threads(&self, count: u32) {
+        let gl = &self.raw;
+        if gl.MaxShaderCompilerThreadsKHR_is_loaded() {
+            gl.MaxShaderCompilerThreadsKHR(count);
+        } else {
+            gl.MaxShaderCompilerThreadsARB(count);
         }
     }
 }

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -917,6 +917,24 @@ impl HasContext for Context {
         }
     }
 
+    unsafe fn get_shader_completion_status(&self, shader: Self::Shader) -> bool {
+        let shaders = self.shaders.borrow();
+        let raw_shader = shaders.get_unchecked(shader);
+        if self.extensions.khr_parallel_shader_compile.is_none() {
+            panic!("Parallel shader compile is not supported")
+        }
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => {
+                gl.get_shader_parameter(raw_shader, COMPLETION_STATUS)
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.get_shader_parameter(raw_shader, COMPLETION_STATUS)
+            }
+        }
+        .as_bool()
+        .unwrap_or(false)
+    }
+
     unsafe fn get_shader_compile_status(&self, shader: Self::Shader) -> bool {
         let shaders = self.shaders.borrow();
         let raw_shader = shaders.get_unchecked(shader);
@@ -1019,6 +1037,24 @@ impl HasContext for Context {
             RawRenderingContext::WebGl1(ref gl) => gl.link_program(raw_program),
             RawRenderingContext::WebGl2(ref gl) => gl.link_program(raw_program),
         }
+    }
+
+    unsafe fn get_program_completion_status(&self, program: Self::Program) -> bool {
+        let programs = self.programs.borrow();
+        let raw_program = programs.get_unchecked(program);
+        if self.extensions.khr_parallel_shader_compile.is_none() {
+            panic!("Parallel shader compile is not supported")
+        }
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => {
+                gl.get_program_parameter(raw_program, COMPLETION_STATUS)
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.get_program_parameter(raw_program, COMPLETION_STATUS)
+            }
+        }
+        .as_bool()
+        .unwrap_or(false)
     }
 
     unsafe fn get_program_link_status(&self, program: Self::Program) -> bool {
@@ -4100,6 +4136,10 @@ impl HasContext for Context {
                 .get_active_uniform_block_name(raw_program, uniform_block_index)
                 .unwrap(),
         }
+    }
+
+    unsafe fn max_shader_compiler_threads(&self, _count: u32) {
+        // WebGL doesn't use this
     }
 }
 


### PR DESCRIPTION
used to compile shaders asynchronously to prevent stalls.

* webgl: https://www.khronos.org/registry/webgl/extensions/KHR_parallel_shader_compile/
* gl: https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_parallel_shader_compile.txt
* gl & gles: https://www.khronos.org/registry/OpenGL/extensions/KHR/KHR_parallel_shader_compile.txt

its still not widely supported however. most real gles devices dont support it, neither does webgl on firefox