### PR TITLE
Add a `bind_external_framebuffer` function to the web sys context

### DIFF
--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -705,6 +705,13 @@ impl Context {
             }
         }
     }
+
+    pub unsafe fn bind_raw_framebuffer(&self, target: u32, framebuffer: &WebGlFramebuffer) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => gl.bind_framebuffer(target, Some(framebuffer)),
+            RawRenderingContext::WebGl2(ref gl) => gl.bind_framebuffer(target, Some(framebuffer)),
+        }
+    }
 }
 
 new_key_type! { pub struct WebShaderKey; }

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -706,7 +706,7 @@ impl Context {
         }
     }
 
-    pub unsafe fn bind_raw_framebuffer(&self, target: u32, framebuffer: &WebGlFramebuffer) {
+    pub unsafe fn bind_external_framebuffer(&self, target: u32, framebuffer: &WebGlFramebuffer) {
         match self.raw {
             RawRenderingContext::WebGl1(ref gl) => gl.bind_framebuffer(target, Some(framebuffer)),
             RawRenderingContext::WebGl2(ref gl) => gl.bind_framebuffer(target, Some(framebuffer)),


### PR DESCRIPTION
This is necessary in order to bind the external framebuffer that you get from WebXR: https://developer.mozilla.org/en-US/docs/Web/API/XRWebGLLayer/framebuffer

I'm using this for my branch of wgpu that can render to WebXR framebuffers: https://github.com/gfx-rs/wgpu/compare/master...expenses:webxr