### PR TITLE
deprecate *_from_gl_name functions (native)

### DIFF
--- a/src/native.rs
+++ b/src/native.rs
@@ -90,6 +90,7 @@ impl Context {
     ///
     /// This can be useful when a texture is created outside of glow (e.g. OpenXR surface) but glow
     /// still needs access to it for rendering.
+    #[deprecated = "Use the NativeTexture constructor instead"]
     pub unsafe fn create_texture_from_gl_name(gl_name: native_gl::GLuint) -> NativeTexture {
         NativeTexture(non_zero_gl_name(gl_name))
     }
@@ -98,6 +99,7 @@ impl Context {
     ///
     /// This can be useful when a framebuffer is created outside of glow (e.g: via `surfman` or another
     /// crate that supports sharing of buffers between GL contexts), but glow needs to set it as a target.
+    #[deprecated = "Use the NativeFramebuffer constructor instead"]
     pub unsafe fn create_framebuffer_from_gl_name(gl_name: native_gl::GLuint) -> NativeFramebuffer {
         NativeFramebuffer(non_zero_gl_name(gl_name))
     }


### PR DESCRIPTION
The constructors for the Native* types are public now and therefore these from_gl_name functions are redundant.