### PR TITLE
Support `lose_context()` / `restore_context()` in WebGL

### DIFF
--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -1328,6 +1328,23 @@ impl Context {
             })
             .unwrap_or(false)
     }
+
+    /// Simulate losing WebGL rendering context.
+    /// Only works when "WEBGL_lose_context" extension is available.
+    pub fn lose_context(&self) {
+        if let Some(ext) = &self.extensions.webgl_lose_context {
+            ext.lose_context()
+        }
+    }
+
+    /// Simulate restoring WebGL rendering context.
+    /// Only works when "WEBGL_lose_context" extension is available.
+    /// This will panic when the context is not lost.
+    pub fn restore_context(&self) {
+        if let Some(ext) = &self.extensions.webgl_lose_context {
+            ext.restore_context()
+        }
+    }
 }
 
 new_key_type! { pub struct WebShaderKey; }


### PR DESCRIPTION
Hi! Thank you for great library 👋 

This PR adds `lose_context()` / `restore_context()` to the Context for WebGL.
They are used for debugging WebGL context lost events.

Ref:
- https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_lose_context/loseContext
- https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_lose_context/restoreContext