### PR TITLE
Make sure debug callback is kept alive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub type Renderbuffer = <Context as HasContext>::Renderbuffer;
 pub type Query = <Context as HasContext>::Query;
 pub type UniformLocation = <Context as HasContext>::UniformLocation;
 pub type TransformFeedback = <Context as HasContext>::TransformFeedback;
+pub type DebugCallback = Box<dyn FnMut(u32, u32, u32, u32, &str)>;
 
 pub struct ActiveUniform {
     pub size: i32,
@@ -1146,9 +1147,9 @@ pub trait HasContext {
     ) where
         S: AsRef<str>;
 
-    unsafe fn debug_message_callback<F>(&self, callback: F)
-    where
-        F: FnMut(u32, u32, u32, u32, &str);
+        unsafe fn debug_message_callback<F>(&mut self, callback: F)
+        where
+            F: FnMut(u32, u32, u32, u32, &str) + 'static;
 
     unsafe fn get_debug_message_log(&self, count: u32) -> Vec<DebugMessageLogEntry>;
 

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -4329,9 +4329,9 @@ impl HasContext for Context {
         panic!("WebGL does not support the KHR_debug extension.")
     }
 
-    unsafe fn debug_message_callback<F>(&self, _callback: F)
+    unsafe fn debug_message_callback<F>(&mut self, callback: F)
     where
-        F: FnMut(u32, u32, u32, u32, &str),
+        F: FnMut(u32, u32, u32, u32, &str) + 'static,
     {
         panic!("WebGL does not support the KHR_debug extension.")
     }


### PR DESCRIPTION
Fixes #256

See comment for why we don't store the debug callback as `Box<Box<dyn FnMut(...)>>` directly - tl;dr is that aliasing isn't fully defined for `Box` so we can't guarantee that the raw pointer we pass out is still valid once it's being aliased during the callback.