### PR TITLE
Switch to latest CI runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,6 @@ jobs:
         override: true
         profile: minimal
         target: wasm32-unknown-unknown
-    # https://github.com/alexcrichton/scoped-tls/issues/20
-    - run: cargo update -p scoped-tls --precise 1.0.0
-      if: matrix.build == 'pinned'
     - run: cargo build --verbose
     - run: cargo build --verbose --target wasm32-unknown-unknown
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         include:
         - build: pinned
           os: ubuntu-latest
-          rust: 1.56.0
+          rust: 1.60.0
           sdl: true
         - build: stable
           os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,33 +14,33 @@ jobs:
         build: [pinned, stable, beta, nightly, macos, windows]
         include:
         - build: pinned
-          os: ubuntu-18.04
+          os: ubuntu-latest
           rust: 1.56.0
           sdl: true
         - build: stable
-          os: ubuntu-18.04
+          os: ubuntu-latest
           rust: stable
           sdl: true
         - build: beta
-          os: ubuntu-18.04
+          os: ubuntu-latest
           rust: beta
           sdl: true
         - build: nightly
-          os: ubuntu-18.04
+          os: ubuntu-latest
           rust: nightly
           sdl: true
         - build: macos
-          os: macos-10.15
+          os: macos-latest
           rust: stable
           sdl: false
         - build: windows
-          os: windows-2019
+          os: windows-latest
           rust: stable
           sdl: false
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Install toolchain 
+    - name: Install toolchain
       uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ matrix.rust }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         include:
         - build: pinned
           os: ubuntu-latest
-          rust: 1.60.0
+          rust: 1.61.0
           sdl: true
         - build: stable
           os: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </div>
 <br />
 <div align="center">
-  <img src="https://img.shields.io/badge/min%20rust-1.60-green.svg" alt="Minimum Rust Version">
+  <img src="https://img.shields.io/badge/min%20rust-1.61-green.svg" alt="Minimum Rust Version">
   <a href="https://crates.io/crates/glow"><img src="https://img.shields.io/crates/v/glow.svg?label=glow" alt="crates.io"></a>
   <a href="https://docs.rs/glow"><img src="https://docs.rs/glow/badge.svg" alt="docs.rs"></a>
   <a href="https://github.com/grovesNL/glow/actions"><img src="https://github.com/grovesNL/glow/workflows/CI/badge.svg?branch=main" alt="Build Status" /></a>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </div>
 <br />
 <div align="center">
-  <img src="https://img.shields.io/badge/Min%20Rust-1.56-green.svg" alt="Minimum Rust Version">
+  <img src="https://img.shields.io/badge/min%20rust-1.60-green.svg" alt="Minimum Rust Version">
   <a href="https://crates.io/crates/glow"><img src="https://img.shields.io/crates/v/glow.svg?label=glow" alt="crates.io"></a>
   <a href="https://docs.rs/glow"><img src="https://docs.rs/glow/badge.svg" alt="docs.rs"></a>
   <a href="https://github.com/grovesNL/glow/actions"><img src="https://github.com/grovesNL/glow/workflows/CI/badge.svg?branch=main" alt="Build Status" /></a>


### PR DESCRIPTION
Upgrade to `latest` CI runners, because sometimes older versions are dropped and we're not going to stay on top of these enough to keep up.