### PR TITLE
Make debug message callback Send + Sync. 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub type Renderbuffer = <Context as HasContext>::Renderbuffer;
 pub type Query = <Context as HasContext>::Query;
 pub type UniformLocation = <Context as HasContext>::UniformLocation;
 pub type TransformFeedback = <Context as HasContext>::TransformFeedback;
-pub type DebugCallback = Box<dyn FnMut(u32, u32, u32, u32, &str)>;
+pub type DebugCallback = Box<dyn FnMut(u32, u32, u32, u32, &str) + Send + Sync>;
 
 pub struct ActiveUniform {
     pub size: i32,
@@ -1191,7 +1191,7 @@ pub trait HasContext {
 
     unsafe fn debug_message_callback<F>(&mut self, callback: F)
     where
-        F: FnMut(u32, u32, u32, u32, &str) + 'static;
+        F: FnMut(u32, u32, u32, u32, &str) + Send + Sync + 'static;
 
     unsafe fn get_debug_message_log(&self, count: u32) -> Vec<DebugMessageLogEntry>;
 

--- a/src/native.rs
+++ b/src/native.rs
@@ -3218,3 +3218,20 @@ extern "system" fn raw_debug_message_callback(
         (callback)(source, gltype, id, severity, msg);
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Context>();
+    }
+
+    #[test]
+    fn test_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Context>();
+    }
+}

--- a/src/native.rs
+++ b/src/native.rs
@@ -19,6 +19,9 @@ struct DebugCallbackRawPtr {
     callback: *mut std::os::raw::c_void,
 }
 
+unsafe impl Send for DebugCallbackRawPtr {}
+unsafe impl Sync for DebugCallbackRawPtr {}
+
 impl Drop for DebugCallbackRawPtr {
     fn drop(&mut self) {
         unsafe {
@@ -2707,7 +2710,7 @@ impl HasContext for Context {
 
     unsafe fn debug_message_callback<F>(&mut self, callback: F)
     where
-        F: FnMut(u32, u32, u32, u32, &str) + 'static,
+        F: FnMut(u32, u32, u32, u32, &str) + Send + Sync + 'static,
     {
         match self.debug_callback {
             Some(_) => {


### PR DESCRIPTION
The debug callback function was not required to be Send+Sync.
This caused the native `Context` struct to become !Send + !Sync, which
is problematic because an OpenGL context can be passed to another
thread.

Fixes #266.