### PR TITLE
feat: add named_buffer_{data_size,sub_data_u8_slice}

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,11 +254,20 @@ pub trait HasContext {
 
     unsafe fn buffer_data_size(&self, target: u32, size: i32, usage: u32);
 
+    unsafe fn named_buffer_data_size(&self, buffer: Self::Buffer, size: i32, usage: u32);
+
     unsafe fn buffer_data_u8_slice(&self, target: u32, data: &[u8], usage: u32);
 
     unsafe fn named_buffer_data_u8_slice(&self, buffer: Self::Buffer, data: &[u8], usage: u32);
 
     unsafe fn buffer_sub_data_u8_slice(&self, target: u32, offset: i32, src_data: &[u8]);
+
+    unsafe fn named_buffer_sub_data_u8_slice(
+        &self,
+        buffer: Self::Buffer,
+        offset: i32,
+        src_data: &[u8],
+    );
 
     unsafe fn get_buffer_sub_data(&self, target: u32, offset: i32, dst_data: &mut [u8]);
 

--- a/src/native.rs
+++ b/src/native.rs
@@ -671,6 +671,11 @@ impl HasContext for Context {
         gl.BufferData(target, size as isize, std::ptr::null(), usage);
     }
 
+    unsafe fn named_buffer_data_size(&self, buffer: Self::Buffer, size: i32, usage: u32) {
+        let gl = &self.raw;
+        gl.NamedBufferData(buffer.0.get(), size as isize, std::ptr::null(), usage);
+    }
+
     unsafe fn buffer_data_u8_slice(&self, target: u32, data: &[u8], usage: u32) {
         let gl = &self.raw;
         gl.BufferData(
@@ -695,6 +700,21 @@ impl HasContext for Context {
         let gl = &self.raw;
         gl.BufferSubData(
             target,
+            offset as isize,
+            src_data.len() as isize,
+            src_data.as_ptr() as *const std::ffi::c_void,
+        );
+    }
+
+    unsafe fn named_buffer_sub_data_u8_slice(
+        &self,
+        buffer: Self::Buffer,
+        offset: i32,
+        src_data: &[u8],
+    ) {
+        let gl = &self.raw;
+        gl.NamedBufferSubData(
+            buffer.0.get(),
             offset as isize,
             src_data.len() as isize,
             src_data.as_ptr() as *const std::ffi::c_void,

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -2027,6 +2027,10 @@ impl HasContext for Context {
         }
     }
 
+    unsafe fn named_buffer_data_size(&self, _buffer: Self::Buffer, _size: i32, _usage: u32) {
+        unimplemented!()
+    }
+
     unsafe fn buffer_data_u8_slice(&self, target: u32, data: &[u8], usage: u32) {
         match self.raw {
             RawRenderingContext::WebGl1(ref gl) => {
@@ -2055,6 +2059,15 @@ impl HasContext for Context {
                 gl.buffer_sub_data_with_i32_and_array_buffer_view(target, offset, &array);
             }
         }
+    }
+
+    unsafe fn named_buffer_sub_data_u8_slice(
+        &self,
+        _buffer: Self::Buffer,
+        _offset: i32,
+        _src_data: &[u8],
+    ) {
+        unimplemented!()
     }
 
     unsafe fn get_buffer_sub_data(&self, target: u32, offset: i32, dst_data: &mut [u8]) {


### PR DESCRIPTION
There is a `named_` version of `buffer_data_u8_slice`, but not `buffer_data_size` and `buffer_sub_data_u8_slice`.