### PR TITLE
Fix panic on invalid string in debug_message_callback

### DIFF
--- a/src/native.rs
+++ b/src/native.rs
@@ -3214,8 +3214,8 @@ extern "system" fn raw_debug_message_callback(
     let _result = std::panic::catch_unwind(move || unsafe {
         let callback: &mut DebugCallback = &mut *(user_param as *mut DebugCallback);
         let slice = std::slice::from_raw_parts(message as *const u8, length as usize);
-        let msg = std::str::from_utf8(slice).unwrap();
-        (callback)(source, gltype, id, severity, msg);
+        let msg = String::from_utf8_lossy(slice);
+        (callback)(source, gltype, id, severity, &msg);
     });
 }
 


### PR DESCRIPTION
I stumble in a case where  the debug_message_callback where panic'ing on non utf8 strings on android, and because I was using panic abort, it was crashing the library.

I didn't investigate why the debug callback was receiving invalid strings. I stumble on it while porting a WGPU application to android. It is happening together with a `FramebufferTexture2d::<attachment> is not valid` error, that logged many times per frame, which I still need to investigate, not sure if it is related.