### PR TITLE
Add support for vertex attrib format f64

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1071,6 +1071,15 @@ pub trait HasContext {
         relative_offset: u32,
     );
 
+    unsafe fn vertex_array_attrib_format_f64(
+        &self,
+        vao: Self::VertexArray,
+        index: u32,
+        size: i32,
+        data_type: u32,
+        relative_offset: u32,
+    );
+
     unsafe fn vertex_array_element_buffer(
         &self,
         vao: Self::VertexArray,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1133,6 +1133,14 @@ pub trait HasContext {
         relative_offset: u32,
     );
 
+    unsafe fn vertex_attrib_format_f64(
+        &self,
+        index: u32,
+        size: i32,
+        data_type: u32,
+        relative_offset: u32,
+    );
+
     unsafe fn vertex_attrib_1_f32(&self, index: u32, x: f32);
 
     unsafe fn vertex_attrib_2_f32(&self, index: u32, x: f32, y: f32);

--- a/src/native.rs
+++ b/src/native.rs
@@ -2561,6 +2561,17 @@ impl HasContext for Context {
         gl.VertexAttribIFormat(index, size, data_type, relative_offset);
     }
 
+    unsafe fn vertex_attrib_format_f64(
+        &self,
+        index: u32,
+        size: i32,
+        data_type: u32,
+        relative_offset: u32,
+    ) {
+        let gl = &self.raw;
+        gl.VertexAttribLFormat(index, size, data_type, relative_offset);
+    }
+
     unsafe fn vertex_attrib_1_f32(&self, index: u32, x: f32) {
         let gl = &self.raw;
         gl.VertexAttrib1f(index, x);

--- a/src/native.rs
+++ b/src/native.rs
@@ -2450,6 +2450,18 @@ impl HasContext for Context {
         gl.VertexArrayAttribIFormat(vao.0.get(), index, size, data_type, relative_offset);
     }
 
+    unsafe fn vertex_array_attrib_format_f64(
+        &self,
+        vao: Self::VertexArray,
+        index: u32,
+        size: i32,
+        data_type: u32,
+        relative_offset: u32,
+    ) {
+        let gl = &self.raw;
+        gl.VertexArrayAttribLFormat(vao.0.get(), index, size, data_type, relative_offset);
+    }
+
     unsafe fn vertex_array_element_buffer(
         &self,
         vao: Self::VertexArray,

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -4250,6 +4250,16 @@ impl HasContext for Context {
         panic!("Vertex attrib format is not supported in WebGL");
     }
 
+    unsafe fn vertex_attrib_format_f64(
+        &self,
+        _index: u32,
+        _size: i32,
+        _data_type: u32,
+        _relative_offset: u32,
+    ) {
+        panic!("Vertex attrib format is not supported in WebGL");
+    }
+
     unsafe fn vertex_attrib_1_f32(&self, index: u32, x: f32) {
         match self.raw {
             RawRenderingContext::WebGl1(ref gl) => gl.vertex_attrib1f(index, x),

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -4154,6 +4154,17 @@ impl HasContext for Context {
         unimplemented!()
     }
 
+    unsafe fn vertex_array_attrib_format_f64(
+        &self,
+        _vao: Self::VertexArray,
+        _index: u32,
+        _size: i32,
+        _data_type: u32,
+        _relative_offset: u32,
+    ) {
+        unimplemented!()
+    }
+
     unsafe fn vertex_array_element_buffer(
         &self,
         _vao: Self::VertexArray,


### PR DESCRIPTION
While working with wgpu and experimenting with vertex formats, I found that they weren't implemented for f64, as they require `glVertexAttribLFormat` which wasn't implemented.
