### PR TITLE
Update 'hello' example to use glutin v0.31 and winit v0.29 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         include:
         - build: pinned
           os: ubuntu-latest
-          rust: 1.64.0
+          rust: 1.65.0
           sdl: true
         - build: stable
           os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       env:
         RUSTFLAGS: --cfg=web_sys_unstable_apis 
     - run: cargo test --verbose
-    - run: (cd examples/hello && cargo build --features glutin)
+    - run: (cd examples/hello && cargo build --features glutin_winit)
     - run: (cd examples/hello && cargo build --target wasm32-unknown-unknown)
     - name: sdl
       if: ${{ matrix.sdl == true }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         include:
         - build: pinned
           os: ubuntu-latest
-          rust: 1.61.0
+          rust: 1.64.0
           sdl: true
         - build: stable
           os: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </div>
 <br />
 <div align="center">
-  <img src="https://img.shields.io/badge/min%20rust-1.61-green.svg" alt="Minimum Rust Version">
+  <img src="https://img.shields.io/badge/min%20rust-1.64-green.svg" alt="Minimum Rust Version">
   <a href="https://crates.io/crates/glow"><img src="https://img.shields.io/crates/v/glow.svg?label=glow" alt="crates.io"></a>
   <a href="https://docs.rs/glow"><img src="https://docs.rs/glow/badge.svg" alt="docs.rs"></a>
   <a href="https://github.com/grovesNL/glow/actions"><img src="https://github.com/grovesNL/glow/actions/workflows/ci.yml/badge.svg?branch=main" alt="Build Status" /></a>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </div>
 <br />
 <div align="center">
-  <img src="https://img.shields.io/badge/min%20rust-1.64-green.svg" alt="Minimum Rust Version">
+  <img src="https://img.shields.io/badge/min%20rust-1.65-green.svg" alt="Minimum Rust Version">
   <a href="https://crates.io/crates/glow"><img src="https://img.shields.io/crates/v/glow.svg?label=glow" alt="crates.io"></a>
   <a href="https://docs.rs/glow"><img src="https://docs.rs/glow/badge.svg" alt="docs.rs"></a>
   <a href="https://github.com/grovesNL/glow/actions"><img src="https://github.com/grovesNL/glow/actions/workflows/ci.yml/badge.svg?branch=main" alt="Build Status" /></a>

--- a/examples/hello/Cargo.toml
+++ b/examples/hello/Cargo.toml
@@ -7,9 +7,15 @@ edition = "2018"
 glow = { path = "../../" }
 
 [target.'cfg(not(any(target_arch = "wasm32")))'.dependencies]
-glutin = { version = "0.28", optional = true }
+glutin = { version = "0.31.2", optional = true }
+glutin-winit = { version = "0.4.2", optional = true}
+winit = { version = "0.29.10", features = ["rwh_05"], optional = true }
+raw-window-handle = { version = "0.5", optional = true }
 sdl2 = { version = "0.35", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features=["HtmlCanvasElement", "WebGl2RenderingContext", "Window"] }
 wasm-bindgen = { version = "0.2" }
+
+[features]
+glutin_winit = ["glutin", "glutin-winit", "winit", "raw-window-handle"]

--- a/examples/hello/README.md
+++ b/examples/hello/README.md
@@ -2,10 +2,10 @@
 
 ## Native
 
-To run with glutin:
+To run with glutin and winit:
 
 ```shell
-cargo run --features=glutin
+cargo run --features=glutin_winit
 ```
 
 To run with sdl2:

--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -1,5 +1,4 @@
 use glow::*;
-use glutin::config::GlConfig;
 
 fn main() {
     unsafe {
@@ -29,7 +28,7 @@ fn main() {
         #[cfg(feature = "glutin_winit")]
         let (gl, gl_surface, gl_context, shader_version, _window, event_loop) = {
             use glutin::{
-                config::ConfigTemplateBuilder,
+                config::{ConfigTemplateBuilder, GlConfig},
                 context::{ContextApi, ContextAttributesBuilder, NotCurrentGlContext},
                 display::{GetGlDisplay, GlDisplay},
                 surface::{GlSurface, SwapInterval},

--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -1,4 +1,5 @@
 use glow::*;
+use glutin::config::GlConfig;
 
 fn main() {
     unsafe {
@@ -25,21 +26,78 @@ fn main() {
         };
 
         // Create a context from a glutin window on non-wasm32 targets
-        #[cfg(feature = "glutin")]
-        let (gl, shader_version, window, event_loop) = {
-            let event_loop = glutin::event_loop::EventLoop::new();
-            let window_builder = glutin::window::WindowBuilder::new()
+        #[cfg(feature = "glutin_winit")]
+        let (gl, gl_surface, gl_context, shader_version, _window, event_loop) = {
+            use glutin::{
+                config::ConfigTemplateBuilder,
+                context::{ContextApi, ContextAttributesBuilder, NotCurrentGlContext},
+                display::{GetGlDisplay, GlDisplay},
+                surface::{GlSurface, SwapInterval},
+            };
+            use glutin_winit::{DisplayBuilder, GlWindow};
+            use raw_window_handle::HasRawWindowHandle;
+            use std::num::NonZeroU32;
+
+            let event_loop = winit::event_loop::EventLoopBuilder::new().build().unwrap();
+            let window_builder = winit::window::WindowBuilder::new()
                 .with_title("Hello triangle!")
-                .with_inner_size(glutin::dpi::LogicalSize::new(1024.0, 768.0));
-            let window = glutin::ContextBuilder::new()
-                .with_vsync(true)
-                .build_windowed(window_builder, &event_loop)
-                .unwrap()
-                .make_current()
+                .with_inner_size(winit::dpi::LogicalSize::new(1024.0, 768.0));
+
+            let template = ConfigTemplateBuilder::new();
+
+            let display_builder = DisplayBuilder::new().with_window_builder(Some(window_builder));
+
+            let (window, gl_config) = display_builder
+                .build(&event_loop, template, |configs| {
+                    configs
+                        .reduce(|accum, config| {
+                            if config.num_samples() > accum.num_samples() {
+                                config
+                            } else {
+                                accum
+                            }
+                        })
+                        .unwrap()
+                })
                 .unwrap();
-            let gl =
-                glow::Context::from_loader_function(|s| window.get_proc_address(s) as *const _);
-            (gl, "#version 410", window, event_loop)
+
+            let raw_window_handle = window.as_ref().map(|window| window.raw_window_handle());
+
+            let gl_display = gl_config.display();
+            let context_attributes = ContextAttributesBuilder::new()
+                .with_context_api(ContextApi::OpenGl(Some(glutin::context::Version {
+                    major: 4,
+                    minor: 10,
+                })))
+                .build(raw_window_handle);
+
+            let not_current_gl_context = gl_display
+                .create_context(&gl_config, &context_attributes)
+                .unwrap();
+
+            let window = window.unwrap();
+
+            let attrs = window.build_surface_attributes(Default::default());
+            let gl_surface = gl_display
+                .create_window_surface(&gl_config, &attrs)
+                .unwrap();
+
+            let gl_context = not_current_gl_context.make_current(&gl_surface).unwrap();
+
+            let gl = glow::Context::from_loader_function_cstr(|s| gl_display.get_proc_address(s));
+
+            gl_surface
+                .set_swap_interval(&gl_context, SwapInterval::Wait(NonZeroU32::new(1).unwrap()))
+                .unwrap();
+
+            (
+                gl,
+                gl_surface,
+                gl_context,
+                "#version 410",
+                window,
+                event_loop,
+            )
         };
 
         // Create a context from a sdl2 window
@@ -124,37 +182,23 @@ fn main() {
 
         // We handle events differently between targets
 
-        #[cfg(feature = "glutin")]
+        #[cfg(feature = "glutin_winit")]
         {
-            use glutin::event::{Event, WindowEvent};
-            use glutin::event_loop::ControlFlow;
-
-            event_loop.run(move |event, _, control_flow| {
-                *control_flow = ControlFlow::Wait;
-                match event {
-                    Event::LoopDestroyed => {
-                        return;
-                    }
-                    Event::MainEventsCleared => {
-                        window.window().request_redraw();
-                    }
-                    Event::RedrawRequested(_) => {
-                        gl.clear(glow::COLOR_BUFFER_BIT);
-                        gl.draw_arrays(glow::TRIANGLES, 0, 3);
-                        window.swap_buffers().unwrap();
-                    }
-                    Event::WindowEvent { ref event, .. } => match event {
-                        WindowEvent::Resized(physical_size) => {
-                            window.resize(*physical_size);
-                        }
+            use glutin::prelude::GlSurface;
+            use winit::event::{Event, WindowEvent};
+            let _ = event_loop.run(move |event, elwt| {
+                if let Event::WindowEvent { event, .. } = event {
+                    match event {
                         WindowEvent::CloseRequested => {
-                            gl.delete_program(program);
-                            gl.delete_vertex_array(vertex_array);
-                            *control_flow = ControlFlow::Exit
+                            elwt.exit();
+                        }
+                        WindowEvent::RedrawRequested => {
+                            gl.clear(glow::COLOR_BUFFER_BIT);
+                            gl.draw_arrays(glow::TRIANGLES, 0, 3);
+                            gl_surface.swap_buffers(&gl_context).unwrap();
                         }
                         _ => (),
-                    },
-                    _ => (),
+                    }
                 }
             });
         }


### PR DESCRIPTION
Related to issue https://github.com/grovesNL/glow/issues/249.

Since glutin no longer bundles winit, we need a lot of additional dependencies now: winit, glutin-winit and raw-window-handle. I grouped them in a feature named `glutin_winit`.

 The boilerplate to configure the window is a lot longer as well. I am not 100% sure I configured everything correctly, but I mostly stuck with the example code in the glutin repo. 