### PR TITLE
Seal the HasContext trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ pub enum CompressedPixelUnpackData<'a> {
     Slice(&'a [u8]),
 }
 
-pub trait HasContext {
+pub trait HasContext : __private::Sealed {
     type Shader: Copy + Clone + Debug + Eq + Hash + Ord + PartialEq + PartialOrd;
     type Program: Copy + Clone + Debug + Eq + Hash + Ord + PartialEq + PartialOrd;
     type Buffer: Copy + Clone + Debug + Eq + Hash + Ord + PartialEq + PartialOrd;
@@ -4175,3 +4175,9 @@ pub const XOR: u32 = 0x1506;
 pub const ZERO: u32 = 0;
 
 pub const ZERO_TO_ONE: u32 = 0x935F;
+
+mod __private {
+    /// Prevents [`HasContext`] from being implemented outside of this crate.
+    #[doc(hidden)]
+    pub trait Sealed {}
+}

--- a/src/native.rs
+++ b/src/native.rs
@@ -176,6 +176,8 @@ pub struct NativeUniformLocation(pub native_gl::GLuint);
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct NativeTransformFeedback(pub NonZeroU32);
 
+impl crate::__private::Sealed for Context {}
+
 impl HasContext for Context {
     type Shader = NativeShader;
     type Program = NativeProgram;

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -1359,6 +1359,8 @@ new_key_type! { pub struct WebRenderbufferKey; }
 new_key_type! { pub struct WebQueryKey; }
 new_key_type! { pub struct WebTransformFeedbackKey; }
 
+impl crate::__private::Sealed for Context {}
+
 impl HasContext for Context {
     type Shader = WebShaderKey;
     type Program = WebProgramKey;


### PR DESCRIPTION
In the current iteration of this crate, a new breaking change is needed
every time a method is added to the `HasContext` trait. This is because
a downstream crate could theoretically provide its own implementation of
`HasContext`, and would need to accommodate for these new methods.
However, most users of `glow` do not implement the `HasContext` trait
and only act as consumers of it. This means that downstream crates have
to constantly update `glow` to take advantage of new updates, which can
be annoying.

This commit makes it so it is impossible to implement the `HasContext`
trait outside of this crate. It does this by making a crate-private
`Sealed` trait that is needed for implementors of `HasContext`. This
makes it so methods can be freely added to `HasContext` without needing
to release a new breaking version of `glow`.

The goal of this change is to make `glow` v1.0.0 possible. With this
change it should be possible to release a stable API, assuming none of
the other APIs need to be changed or removed in any way.

The downside of this change is that it becomes impossible to implement
`HasContext` outside of this crate. I would be genuinely shocked if any
such implementations existed
