### PR TITLE
Add support for external images using ImageData

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ features = [
   "HtmlImageElement",
   "HtmlVideoElement",
   "ImageBitmap",
+  "ImageData",
   "VideoFrame",
   "WebGlActiveInfo",
   "WebGlBuffer",

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -4,7 +4,7 @@ use js_sys::{self, Array};
 use slotmap::{new_key_type, SlotMap};
 use std::cell::RefCell;
 use web_sys::{
-    self, HtmlCanvasElement, HtmlImageElement, HtmlVideoElement, ImageBitmap,
+    self, HtmlCanvasElement, HtmlImageElement, HtmlVideoElement, ImageBitmap, ImageData,
     WebGl2RenderingContext, WebGlBuffer, WebGlFramebuffer, WebGlProgram, WebGlQuery,
     WebGlRenderbuffer, WebGlRenderingContext, WebGlSampler, WebGlShader, WebGlSync, WebGlTexture,
     WebGlTransformFeedback, WebGlUniformLocation, WebGlVertexArrayObject,
@@ -308,6 +308,7 @@ impl Context {
     // - html_image
     // - html_video
     // - video_frame
+    // - image_data
 
     pub unsafe fn tex_image_2d_with_image_bitmap(
         &self,
@@ -666,6 +667,77 @@ impl Context {
         }
     }
 
+    pub unsafe fn tex_image_2d_with_image_data(
+        &self,
+        target: u32,
+        level: i32,
+        internal_format: i32,
+        format: u32,
+        ty: u32,
+        pixels: &ImageData,
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => {
+                // TODO: Handle return value?
+                gl.tex_image_2d_with_u32_and_u32_and_image_data(
+                    target,
+                    level,
+                    internal_format,
+                    format,
+                    ty,
+                    pixels,
+                )
+                .unwrap();
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                // TODO: Handle return value?
+                gl.tex_image_2d_with_u32_and_u32_and_image_data(
+                    target,
+                    level,
+                    internal_format,
+                    format,
+                    ty,
+                    pixels,
+                )
+                .unwrap();
+            }
+        }
+    }
+
+    /// WebGL2 Only
+    pub unsafe fn tex_image_2d_with_image_data_and_width_and_height(
+        &self,
+        target: u32,
+        level: i32,
+        internal_format: i32,
+        width: i32,
+        height: i32,
+        format: u32,
+        ty: u32,
+        pixels: &ImageData,
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(_) => {
+                panic!("Width and height not supported")
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                // TODO: Handle return value?
+                gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_image_data(
+                    target,
+                    level,
+                    internal_format,
+                    width,
+                    height,
+                    0, // required to be zero
+                    format,
+                    ty,
+                    pixels,
+                )
+                .unwrap();
+            }
+        }
+    }
+
     pub unsafe fn tex_sub_image_2d_with_image_bitmap(
         &self,
         target: u32,
@@ -950,6 +1022,58 @@ impl Context {
         }
     }
 
+    pub unsafe fn tex_sub_image_2d_with_image_data(
+        &self,
+        target: u32,
+        level: i32,
+        x_offset: i32,
+        y_offset: i32,
+        format: u32,
+        ty: u32,
+        image: &ImageData,
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => {
+                gl.tex_sub_image_2d_with_u32_and_u32_and_image_data(
+                    target, level, x_offset, y_offset, format, ty, image,
+                )
+                .unwrap(); // TODO: Handle return value?
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.tex_sub_image_2d_with_u32_and_u32_and_image_data(
+                    target, level, x_offset, y_offset, format, ty, image,
+                )
+                .unwrap(); // TODO: Handle return value?
+            }
+        }
+    }
+
+    /// WebGL2 Only
+    pub unsafe fn tex_sub_image_2d_with_image_data_and_width_and_height(
+        &self,
+        target: u32,
+        level: i32,
+        x_offset: i32,
+        y_offset: i32,
+        width: i32,
+        height: i32,
+        format: u32,
+        ty: u32,
+        image: &ImageData,
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(_) => {
+                panic!("Width and height not supported")
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.tex_sub_image_2d_with_i32_and_i32_and_u32_and_type_and_image_data(
+                    target, level, x_offset, y_offset, width, height, format, ty, image,
+                )
+                .unwrap(); // TODO: Handle return value?
+            }
+        }
+    }
+
     /// WebGL2 Only
     pub unsafe fn tex_image_3d_with_image_bitmap(
         &self,
@@ -1122,6 +1246,40 @@ impl Context {
     }
 
     /// WebGL2 Only
+    pub unsafe fn tex_image_3d_with_image_data(
+        &self,
+        target: u32,
+        level: i32,
+        internal_format: i32,
+        width: i32,
+        height: i32,
+        depth: i32,
+        border: i32,
+        format: u32,
+        ty: u32,
+        image: &ImageData,
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(_) => panic!("3D images not supported"),
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.tex_image_3d_with_image_data(
+                    target,
+                    level,
+                    internal_format,
+                    width,
+                    height,
+                    depth,
+                    border,
+                    format,
+                    ty,
+                    image,
+                )
+                .unwrap(); // TODO: Handle return value?
+            }
+        }
+    }
+
+    /// WebGL2 Only
     pub unsafe fn tex_sub_image_3d_with_image_bitmap(
         &self,
         target: u32,
@@ -1260,6 +1418,33 @@ impl Context {
                     format,
                     ty,
                     video_frame,
+                )
+                .unwrap(); // TODO: Handle return value?
+            }
+        }
+    }
+
+    /// WebGL2 Only
+    pub unsafe fn tex_sub_image_3d_with_image_data(
+        &self,
+        target: u32,
+        level: i32,
+        x_offset: i32,
+        y_offset: i32,
+        z_offset: i32,
+        width: i32,
+        height: i32,
+        depth: i32,
+        format: u32,
+        ty: u32,
+        image: &ImageData,
+    ) {
+        match self.raw {
+            RawRenderingContext::WebGl1(_) => panic!("3D images not supported"),
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.tex_sub_image_3d_with_image_data(
+                    target, level, x_offset, y_offset, z_offset, width, height, depth, format, ty,
+                    image,
                 )
                 .unwrap(); // TODO: Handle return value?
             }


### PR DESCRIPTION
Adds methods for using ImageData as source for textures. Needed for support of wgpu's ExternalImageSource ImageData.