### PR TITLE
debug_message_callback: use Fn instead of FnMut

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub type Renderbuffer = <Context as HasContext>::Renderbuffer;
 pub type Query = <Context as HasContext>::Query;
 pub type UniformLocation = <Context as HasContext>::UniformLocation;
 pub type TransformFeedback = <Context as HasContext>::TransformFeedback;
-pub type DebugCallback = Box<dyn FnMut(u32, u32, u32, u32, &str) + Send + Sync>;
+pub type DebugCallback = Box<dyn Fn(u32, u32, u32, u32, &str) + Send + Sync>;
 
 pub struct ActiveUniform {
     pub size: i32,
@@ -1523,7 +1523,7 @@ pub trait HasContext: __private::Sealed {
 
     unsafe fn debug_message_callback<F>(&mut self, callback: F)
     where
-        F: FnMut(u32, u32, u32, u32, &str) + Send + Sync + 'static;
+        F: Fn(u32, u32, u32, u32, &str) + Send + Sync + 'static;
 
     unsafe fn get_debug_message_log(&self, count: u32) -> Vec<DebugMessageLogEntry>;
 

--- a/src/native.rs
+++ b/src/native.rs
@@ -3368,7 +3368,7 @@ impl HasContext for Context {
 
     unsafe fn debug_message_callback<F>(&mut self, callback: F)
     where
-        F: FnMut(u32, u32, u32, u32, &str) + Send + Sync + 'static,
+        F: Fn(u32, u32, u32, u32, &str) + Send + Sync + 'static,
     {
         match self.debug_callback {
             Some(_) => {
@@ -3889,7 +3889,7 @@ extern "system" fn raw_debug_message_callback(
     user_param: *mut std::ffi::c_void,
 ) {
     let _result = std::panic::catch_unwind(move || unsafe {
-        let callback: &mut DebugCallback = &mut *(user_param as *mut DebugCallback);
+        let callback: &DebugCallback = &*(user_param as *const DebugCallback);
         let slice = std::slice::from_raw_parts(message as *const u8, length as usize);
         let msg = String::from_utf8_lossy(slice);
         (callback)(source, gltype, id, severity, &msg);


### PR DESCRIPTION
The callback may be called simultaneously from different threads. Thus it must use a non-mutable function.

Fixes #289
