### PR TITLE
Add named framebuffer operations and named vertex arrays

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -508,6 +508,22 @@ pub trait HasContext: __private::Sealed {
         filter: u32,
     );
 
+    unsafe fn blit_named_framebuffer(
+        &self,
+        read_buffer: Option<Self::Framebuffer>,
+        draw_buffer: Option<Self::Framebuffer>,
+        src_x0: i32,
+        src_y0: i32,
+        src_x1: i32,
+        src_y1: i32,
+        dst_x0: i32,
+        dst_y0: i32,
+        dst_x1: i32,
+        dst_y1: i32,
+        mask: u32,
+        filter: u32,
+    );
+
     unsafe fn create_vertex_array(&self) -> Result<Self::VertexArray, String>;
 
     unsafe fn delete_vertex_array(&self, vertex_array: Self::VertexArray);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -820,6 +820,31 @@ pub trait HasContext: __private::Sealed {
         layer: i32,
     );
 
+    unsafe fn named_framebuffer_renderbuffer(
+        &self,
+        framebuffer: Option<Self::Framebuffer>,
+        attachment: u32,
+        renderbuffer_target: u32,
+        renderbuffer: Option<Self::Renderbuffer>,
+    );
+
+    unsafe fn named_framebuffer_texture(
+        &self,
+        framebuffer: Option<Self::Framebuffer>,
+        attachment: u32,
+        texture: Option<Self::Texture>,
+        level: i32,
+    );
+
+    unsafe fn named_framebuffer_texture_layer(
+        &self,
+        framebuffer: Option<Self::Framebuffer>,
+        attachment: u32,
+        texture: Option<Self::Texture>,
+        level: i32,
+        layer: i32,
+    );
+
     unsafe fn front_face(&self, value: u32);
 
     unsafe fn get_error(&self) -> u32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -745,6 +745,12 @@ pub trait HasContext: __private::Sealed {
         draw_buffer: u32,
     );
 
+    unsafe fn named_framebuffer_draw_buffers(
+        &self,
+        framebuffer: Option<Self::Framebuffer>,
+        buffers: &[u32],
+    );
+
     unsafe fn draw_buffers(&self, buffers: &[u32]);
 
     unsafe fn draw_elements(&self, mode: u32, count: i32, element_type: u32, offset: i32);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -571,6 +571,39 @@ pub trait HasContext: __private::Sealed {
         stencil: i32,
     );
 
+    unsafe fn clear_named_framebuffer_i32_slice(
+        &self,
+        framebuffer: Option<Self::Framebuffer>,
+        target: u32,
+        draw_buffer: u32,
+        values: &[i32],
+    );
+
+    unsafe fn clear_named_framebuffer_u32_slice(
+        &self,
+        framebuffer: Option<Self::Framebuffer>,
+        target: u32,
+        draw_buffer: u32,
+        values: &[u32],
+    );
+
+    unsafe fn clear_named_framebuffer_f32_slice(
+        &self,
+        framebuffer: Option<Self::Framebuffer>,
+        target: u32,
+        draw_buffer: u32,
+        values: &[f32],
+    );
+
+    unsafe fn clear_named_framebuffer_depth_stencil(
+        &self,
+        framebuffer: Option<Self::Framebuffer>,
+        target: u32,
+        draw_buffer: u32,
+        depth: f32,
+        stencil: i32,
+    );
+
     unsafe fn client_wait_sync(&self, fence: Self::Fence, flags: u32, timeout: i32) -> u32;
     unsafe fn wait_sync(&self, fence: Self::Fence, flags: u32, timeout: u64);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -889,6 +889,28 @@ pub trait HasContext: __private::Sealed {
 
     unsafe fn get_parameter_string(&self, parameter: u32) -> String;
 
+    unsafe fn get_framebuffer_parameter_i32(&self, target: u32, parameter: u32) -> i32;
+
+    unsafe fn get_named_framebuffer_parameter_i32(
+        &self,
+        framebuffer: Option<Self::Framebuffer>,
+        parameter: u32,
+    ) -> i32;
+
+    unsafe fn get_framebuffer_attachment_parameter_i32(
+        &self,
+        target: u32,
+        attachment: u32,
+        parameter: u32,
+    ) -> i32;
+
+    unsafe fn get_named_framebuffer_attachment_parameter_i32(
+        &self,
+        framebuffer: Option<Self::Framebuffer>,
+        attachment: u32,
+        parameter: u32,
+    ) -> i32;
+
     unsafe fn get_active_uniform_block_parameter_i32(
         &self,
         program: Self::Program,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -719,6 +719,12 @@ pub trait HasContext: __private::Sealed {
 
     unsafe fn draw_buffer(&self, buffer: u32);
 
+    unsafe fn named_framebuffer_draw_buffer(
+        &self,
+        framebuffer: Option<Self::Framebuffer>,
+        draw_buffer: u32,
+    );
+
     unsafe fn draw_buffers(&self, buffers: &[u32]);
 
     unsafe fn draw_elements(&self, mode: u32, count: i32, element_type: u32, offset: i32);
@@ -1622,6 +1628,12 @@ pub trait HasContext: __private::Sealed {
     unsafe fn shader_storage_block_binding(&self, program: Self::Program, index: u32, binding: u32);
 
     unsafe fn read_buffer(&self, src: u32);
+
+    unsafe fn named_framebuffer_read_buffer(
+        &self,
+        framebuffer: Option<Self::Framebuffer>,
+        src: u32,
+    );
 
     unsafe fn read_pixels(
         &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -557,6 +557,12 @@ pub trait HasContext: __private::Sealed {
 
     unsafe fn check_framebuffer_status(&self, target: u32) -> u32;
 
+    unsafe fn check_named_framebuffer_status(
+        &self,
+        framebuffer: Option<Self::Framebuffer>,
+        target: u32,
+    ) -> u32;
+
     unsafe fn clear_buffer_i32_slice(&self, target: u32, draw_buffer: u32, values: &[i32]);
 
     unsafe fn clear_buffer_u32_slice(&self, target: u32, draw_buffer: u32, values: &[u32]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -526,6 +526,8 @@ pub trait HasContext: __private::Sealed {
 
     unsafe fn create_vertex_array(&self) -> Result<Self::VertexArray, String>;
 
+    unsafe fn create_named_vertex_array(&self) -> Result<Self::VertexArray, String>;
+
     unsafe fn delete_vertex_array(&self, vertex_array: Self::VertexArray);
 
     unsafe fn bind_vertex_array(&self, vertex_array: Option<Self::VertexArray>);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,8 @@ pub trait HasContext: __private::Sealed {
 
     unsafe fn create_framebuffer(&self) -> Result<Self::Framebuffer, String>;
 
+    unsafe fn create_named_framebuffer(&self) -> Result<Self::Framebuffer, String>;
+
     unsafe fn is_framebuffer(&self, framebuffer: Self::Framebuffer) -> bool;
 
     unsafe fn create_query(&self) -> Result<Self::Query, String>;

--- a/src/native.rs
+++ b/src/native.rs
@@ -1198,6 +1198,13 @@ impl HasContext for Context {
         Ok(NativeVertexArray(non_zero_gl_name(vertex_array)))
     }
 
+    unsafe fn create_named_vertex_array(&self) -> Result<Self::VertexArray, String> {
+        let gl = &self.raw;
+        let mut vertex_array = 0;
+        gl.CreateVertexArrays(1, &mut vertex_array);
+        Ok(NativeVertexArray(non_zero_gl_name(vertex_array)))
+    }
+
     unsafe fn delete_vertex_array(&self, vertex_array: Self::VertexArray) {
         let gl = &self.raw;
         gl.DeleteVertexArrays(1, &vertex_array.0.get());

--- a/src/native.rs
+++ b/src/native.rs
@@ -1629,6 +1629,15 @@ impl HasContext for Context {
         gl.DrawBuffer(draw_buffer);
     }
 
+    unsafe fn named_framebuffer_draw_buffer(
+        &self,
+        framebuffer: Option<Self::Framebuffer>,
+        draw_buffer: u32,
+    ) {
+        let gl = &self.raw;
+        gl.NamedFramebufferDrawBuffer(framebuffer.map(|f| f.0.get()).unwrap_or(0), draw_buffer);
+    }
+
     unsafe fn draw_buffers(&self, buffers: &[u32]) {
         let gl = &self.raw;
         gl.DrawBuffers(buffers.len() as i32, buffers.as_ptr());
@@ -3701,6 +3710,15 @@ impl HasContext for Context {
     unsafe fn read_buffer(&self, src: u32) {
         let gl = &self.raw;
         gl.ReadBuffer(src);
+    }
+
+    unsafe fn named_framebuffer_read_buffer(
+        &self,
+        framebuffer: Option<Self::Framebuffer>,
+        src: u32,
+    ) {
+        let gl = &self.raw;
+        gl.NamedFramebufferReadBuffer(framebuffer.map(|f| f.0.get()).unwrap_or(0), src);
     }
 
     unsafe fn read_pixels(

--- a/src/native.rs
+++ b/src/native.rs
@@ -1159,6 +1159,38 @@ impl HasContext for Context {
         );
     }
 
+    unsafe fn blit_named_framebuffer(
+        &self,
+        read_buffer: Option<Self::Framebuffer>,
+        draw_buffer: Option<Self::Framebuffer>,
+        src_x0: i32,
+        src_y0: i32,
+        src_x1: i32,
+        src_y1: i32,
+        dst_x0: i32,
+        dst_y0: i32,
+        dst_x1: i32,
+        dst_y1: i32,
+        mask: u32,
+        filter: u32,
+    ) {
+        let gl = &self.raw;
+        gl.BlitNamedFramebuffer(
+            read_buffer.map(|f| f.0.get()).unwrap_or(0),
+            draw_buffer.map(|f| f.0.get()).unwrap_or(0),
+            src_x0,
+            src_y0,
+            src_x1,
+            src_y1,
+            dst_x0,
+            dst_y0,
+            dst_x1,
+            dst_y1,
+            mask,
+            filter,
+        );
+    }
+
     unsafe fn create_vertex_array(&self) -> Result<Self::VertexArray, String> {
         let gl = &self.raw;
         let mut vertex_array = 0;

--- a/src/native.rs
+++ b/src/native.rs
@@ -2015,6 +2015,57 @@ impl HasContext for Context {
             .to_owned()
     }
 
+    unsafe fn get_framebuffer_parameter_i32(&self, target: u32, parameter: u32) -> i32 {
+        let gl = &self.raw;
+        let mut value = 0;
+        gl.GetFramebufferParameteriv(target, parameter, &mut value);
+        value
+    }
+
+    unsafe fn get_named_framebuffer_parameter_i32(
+        &self,
+        framebuffer: Option<Self::Framebuffer>,
+        parameter: u32,
+    ) -> i32 {
+        let gl = &self.raw;
+        let mut value = 0;
+        gl.GetNamedFramebufferParameteriv(
+            framebuffer.map(|f| f.0.get()).unwrap_or(0),
+            parameter,
+            &mut value,
+        );
+        value
+    }
+
+    unsafe fn get_framebuffer_attachment_parameter_i32(
+        &self,
+        target: u32,
+        attachment: u32,
+        parameter: u32,
+    ) -> i32 {
+        let gl = &self.raw;
+        let mut value = 0;
+        gl.GetFramebufferAttachmentParameteriv(target, attachment, parameter, &mut value);
+        value
+    }
+
+    unsafe fn get_named_framebuffer_attachment_parameter_i32(
+        &self,
+        framebuffer: Option<Self::Framebuffer>,
+        attachment: u32,
+        parameter: u32,
+    ) -> i32 {
+        let gl = &self.raw;
+        let mut value = 0;
+        gl.GetNamedFramebufferAttachmentParameteriv(
+            framebuffer.map(|f| f.0.get()).unwrap_or(0),
+            attachment,
+            parameter,
+            &mut value,
+        );
+        value
+    }
+
     unsafe fn get_uniform_location(
         &self,
         program: Self::Program,

--- a/src/native.rs
+++ b/src/native.rs
@@ -1342,6 +1342,72 @@ impl HasContext for Context {
         gl.ClearBufferfi(target, draw_buffer as i32, depth, stencil);
     }
 
+    unsafe fn clear_named_framebuffer_i32_slice(
+        &self,
+        framebuffer: Option<Self::Framebuffer>,
+        target: u32,
+        draw_buffer: u32,
+        values: &[i32],
+    ) {
+        let gl = &self.raw;
+        gl.ClearNamedFramebufferiv(
+            framebuffer.map(|f| f.0.get()).unwrap_or(0),
+            target,
+            draw_buffer as i32,
+            values.as_ptr(),
+        );
+    }
+
+    unsafe fn clear_named_framebuffer_u32_slice(
+        &self,
+        framebuffer: Option<Self::Framebuffer>,
+        target: u32,
+        draw_buffer: u32,
+        values: &[u32],
+    ) {
+        let gl = &self.raw;
+        gl.ClearNamedFramebufferuiv(
+            framebuffer.map(|f| f.0.get()).unwrap_or(0),
+            target,
+            draw_buffer as i32,
+            values.as_ptr(),
+        );
+    }
+
+    unsafe fn clear_named_framebuffer_f32_slice(
+        &self,
+        framebuffer: Option<Self::Framebuffer>,
+        target: u32,
+        draw_buffer: u32,
+        values: &[f32],
+    ) {
+        let gl = &self.raw;
+        gl.ClearNamedFramebufferfv(
+            framebuffer.map(|f| f.0.get()).unwrap_or(0),
+            target,
+            draw_buffer as i32,
+            values.as_ptr(),
+        );
+    }
+
+    unsafe fn clear_named_framebuffer_depth_stencil(
+        &self,
+        framebuffer: Option<Self::Framebuffer>,
+        target: u32,
+        draw_buffer: u32,
+        depth: f32,
+        stencil: i32,
+    ) {
+        let gl = &self.raw;
+        gl.ClearNamedFramebufferfi(
+            framebuffer.map(|f| f.0.get()).unwrap_or(0),
+            target,
+            draw_buffer as i32,
+            depth,
+            stencil,
+        );
+    }
+
     unsafe fn client_wait_sync(&self, fence: Self::Fence, flags: u32, timeout: i32) -> u32 {
         let gl = &self.raw;
         gl.ClientWaitSync(fence.0, flags, timeout as u64)

--- a/src/native.rs
+++ b/src/native.rs
@@ -1316,6 +1316,15 @@ impl HasContext for Context {
         gl.CheckFramebufferStatus(target)
     }
 
+    unsafe fn check_named_framebuffer_status(
+        &self,
+        framebuffer: Option<Self::Framebuffer>,
+        target: u32,
+    ) -> u32 {
+        let gl = &self.raw;
+        gl.CheckNamedFramebufferStatus(framebuffer.map(|f| f.0.get()).unwrap_or(0), target)
+    }
+
     unsafe fn clear_buffer_i32_slice(&self, target: u32, draw_buffer: u32, values: &[i32]) {
         let gl = &self.raw;
         gl.ClearBufferiv(target, draw_buffer as i32, values.as_ptr());

--- a/src/native.rs
+++ b/src/native.rs
@@ -1845,6 +1845,56 @@ impl HasContext for Context {
         );
     }
 
+    unsafe fn named_framebuffer_renderbuffer(
+        &self,
+        framebuffer: Option<Self::Framebuffer>,
+        attachment: u32,
+        renderbuffer_target: u32,
+        renderbuffer: Option<Self::Renderbuffer>,
+    ) {
+        let gl = &self.raw;
+        gl.NamedFramebufferRenderbuffer(
+            framebuffer.map(|f| f.0.get()).unwrap_or(0),
+            attachment,
+            renderbuffer_target,
+            renderbuffer.map(|rb| rb.0.get()).unwrap_or(0),
+        );
+    }
+
+    unsafe fn named_framebuffer_texture(
+        &self,
+        framebuffer: Option<Self::Framebuffer>,
+        attachment: u32,
+        texture: Option<Self::Texture>,
+        level: i32,
+    ) {
+        let gl = &self.raw;
+        gl.NamedFramebufferTexture(
+            framebuffer.map(|f| f.0.get()).unwrap_or(0),
+            attachment,
+            texture.map(|t| t.0.get()).unwrap_or(0),
+            level,
+        );
+    }
+
+    unsafe fn named_framebuffer_texture_layer(
+        &self,
+        framebuffer: Option<Self::Framebuffer>,
+        attachment: u32,
+        texture: Option<Self::Texture>,
+        level: i32,
+        layer: i32,
+    ) {
+        let gl = &self.raw;
+        gl.NamedFramebufferTextureLayer(
+            framebuffer.map(|f| f.0.get()).unwrap_or(0),
+            attachment,
+            texture.map(|t| t.0.get()).unwrap_or(0),
+            level,
+            layer,
+        );
+    }
+
     unsafe fn front_face(&self, value: u32) {
         let gl = &self.raw;
         gl.FrontFace(value as u32);

--- a/src/native.rs
+++ b/src/native.rs
@@ -220,6 +220,13 @@ impl HasContext for Context {
         Ok(NativeFramebuffer(non_zero_gl_name(name)))
     }
 
+    unsafe fn create_named_framebuffer(&self) -> Result<Self::Framebuffer, String> {
+        let gl = &self.raw;
+        let mut name = 0;
+        gl.CreateFramebuffers(1, &mut name);
+        Ok(NativeFramebuffer(non_zero_gl_name(name)))
+    }
+
     unsafe fn is_framebuffer(&self, framebuffer: Self::Framebuffer) -> bool {
         let gl = &self.raw;
         gl.IsFramebuffer(framebuffer.0.get()) != 0

--- a/src/native.rs
+++ b/src/native.rs
@@ -1689,6 +1689,19 @@ impl HasContext for Context {
         gl.DrawBuffers(buffers.len() as i32, buffers.as_ptr());
     }
 
+    unsafe fn named_framebuffer_draw_buffers(
+        &self,
+        framebuffer: Option<Self::Framebuffer>,
+        buffers: &[u32],
+    ) {
+        let gl = &self.raw;
+        gl.NamedFramebufferDrawBuffers(
+            framebuffer.map(|f| f.0.get()).unwrap_or(0),
+            buffers.len() as i32,
+            buffers.as_ptr(),
+        );
+    }
+
     unsafe fn draw_elements(&self, mode: u32, count: i32, element_type: u32, offset: i32) {
         let gl = &self.raw;
         gl.DrawElements(

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -3042,6 +3042,14 @@ impl HasContext for Context {
         }
     }
 
+    unsafe fn named_framebuffer_draw_buffers(
+        &self,
+        _framebuffer: Option<Self::Framebuffer>,
+        _draw_buffers: &[u32],
+    ) {
+        panic!("Named framebuffers are not supported");
+    }
+
     unsafe fn draw_elements(&self, mode: u32, count: i32, element_type: u32, offset: i32) {
         match self.raw {
             RawRenderingContext::WebGl1(ref gl) => {

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -3214,6 +3214,37 @@ impl HasContext for Context {
         }
     }
 
+    unsafe fn named_framebuffer_renderbuffer(
+        &self,
+        _framebuffer: Option<Self::Framebuffer>,
+        _attachment: u32,
+        _renderbuffer_target: u32,
+        _renderbuffer: Option<Self::Renderbuffer>,
+    ) {
+        panic!("Named framebuffers are not supported");
+    }
+
+    unsafe fn named_framebuffer_texture(
+        &self,
+        _framebuffer: Option<Self::Framebuffer>,
+        _attachment: u32,
+        _texture: Option<Self::Texture>,
+        _level: i32,
+    ) {
+        panic!("Named framebuffers are not supported");
+    }
+
+    unsafe fn named_framebuffer_texture_layer(
+        &self,
+        _framebuffer: Option<Self::Framebuffer>,
+        _attachment: u32,
+        _texture: Option<Self::Texture>,
+        _level: i32,
+        _layer: i32,
+    ) {
+        panic!("Named framebuffers are not supported");
+    }
+
     unsafe fn front_face(&self, value: u32) {
         match self.raw {
             RawRenderingContext::WebGl1(ref gl) => gl.front_face(value as u32),

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -2986,6 +2986,14 @@ impl HasContext for Context {
         }
     }
 
+    unsafe fn named_framebuffer_draw_buffer(
+        &self,
+        _framebuffer: Option<Self::Framebuffer>,
+        _draw_buffer: u32,
+    ) {
+        panic!("Named framebuffers are not supported");
+    }
+
     unsafe fn draw_buffers(&self, buffers: &[u32]) {
         match self.raw {
             RawRenderingContext::WebGl1(ref _gl) => {
@@ -5202,6 +5210,14 @@ impl HasContext for Context {
             RawRenderingContext::WebGl1(..) => panic!("read_buffer is not supported by WebGL1"),
             RawRenderingContext::WebGl2(ref gl) => gl.read_buffer(src),
         }
+    }
+
+    unsafe fn named_framebuffer_read_buffer(
+        &self,
+        _framebuffer: Option<Self::Framebuffer>,
+        _src: u32,
+    ) {
+        panic!("Named framebuffers are not supported");
     }
 
     unsafe fn read_pixels(

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -3404,6 +3404,49 @@ impl HasContext for Context {
         .unwrap_or_else(|| String::from(""))
     }
 
+    unsafe fn get_framebuffer_parameter_i32(&self, _target: u32, _parameter: u32) -> i32 {
+        panic!("Get framebuffer parameter is not supported");
+    }
+
+    unsafe fn get_named_framebuffer_parameter_i32(
+        &self,
+        _framebuffer: Option<Self::Framebuffer>,
+        _parameter: u32,
+    ) -> i32 {
+        panic!("Named framebuffers are not supported");
+    }
+
+    unsafe fn get_framebuffer_attachment_parameter_i32(
+        &self,
+        target: u32,
+        attachment: u32,
+        parameter: u32,
+    ) -> i32 {
+        match self.raw {
+            RawRenderingContext::WebGl1(ref gl) => {
+                gl.get_framebuffer_attachment_parameter(target, attachment, parameter)
+            }
+            RawRenderingContext::WebGl2(ref gl) => {
+                gl.get_framebuffer_attachment_parameter(target, attachment, parameter)
+            }
+        }
+        .unwrap()
+        .as_f64()
+        .map(|v| v as i32)
+        // Errors will be caught by the browser or through `get_error`
+        // so return a default instead
+        .unwrap_or(0)
+    }
+
+    unsafe fn get_named_framebuffer_attachment_parameter_i32(
+        &self,
+        _framebuffer: Option<Self::Framebuffer>,
+        _attachment: u32,
+        _parameter: u32,
+    ) -> i32 {
+        panic!("Named framebuffers are not supported");
+    }
+
     unsafe fn get_uniform_location(
         &self,
         program: Self::Program,

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -2469,6 +2469,9 @@ impl HasContext for Context {
         }
     }
 
+    unsafe fn create_named_vertex_array(&self) -> Result<Self::VertexArray, String> {
+        unimplemented!()
+    }
     unsafe fn delete_vertex_array(&self, vertex_array: Self::VertexArray) {
         let mut vertex_arrays = self.vertex_arrays.borrow_mut();
         if let Some(ref va) = vertex_arrays.remove(vertex_array) {

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -2431,6 +2431,24 @@ impl HasContext for Context {
         }
     }
 
+    unsafe fn blit_named_framebuffer(
+        &self,
+        _read_buffer: Option<Self::Framebuffer>,
+        _draw_buffer: Option<Self::Framebuffer>,
+        _src_x0: i32,
+        _src_y0: i32,
+        _src_x1: i32,
+        _src_y1: i32,
+        _dst_x0: i32,
+        _dst_y0: i32,
+        _dst_x1: i32,
+        _dst_y1: i32,
+        _mask: u32,
+        _filter: u32,
+    ) {
+        panic!("Named framebuffers are not supported");
+    }
+
     unsafe fn create_vertex_array(&self) -> Result<Self::VertexArray, String> {
         let raw_vertex_array = match self.raw {
             RawRenderingContext::WebGl1(ref _gl) => {

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -1587,6 +1587,10 @@ impl HasContext for Context {
         }
     }
 
+    unsafe fn create_named_framebuffer(&self) -> Result<Self::Framebuffer, String> {
+        panic!("Named framebuffers are not supported");
+    }
+
     unsafe fn is_framebuffer(&self, framebuffer: Self::Framebuffer) -> bool {
         let framebuffers = self.framebuffers.borrow_mut();
         if let Some(ref f) = framebuffers.get(framebuffer) {

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -2664,6 +2664,47 @@ impl HasContext for Context {
         }
     }
 
+    unsafe fn clear_named_framebuffer_i32_slice(
+        &self,
+        _framebuffer: Option<Self::Framebuffer>,
+        _target: u32,
+        _draw_buffer: u32,
+        _values: &[i32],
+    ) {
+        panic!("Named framebuffers are not supported");
+    }
+
+    unsafe fn clear_named_framebuffer_u32_slice(
+        &self,
+        _framebuffer: Option<Self::Framebuffer>,
+        _target: u32,
+        _draw_buffer: u32,
+        _values: &[u32],
+    ) {
+        panic!("Named framebuffers are not supported");
+    }
+
+    unsafe fn clear_named_framebuffer_f32_slice(
+        &self,
+        _framebuffer: Option<Self::Framebuffer>,
+        _target: u32,
+        _draw_buffer: u32,
+        _values: &[f32],
+    ) {
+        panic!("Named framebuffers are not supported");
+    }
+
+    unsafe fn clear_named_framebuffer_depth_stencil(
+        &self,
+        _framebuffer: Option<Self::Framebuffer>,
+        _target: u32,
+        _draw_buffer: u32,
+        _depth: f32,
+        _stencil: i32,
+    ) {
+        panic!("Named framebuffers are not supported");
+    }
+
     unsafe fn client_wait_sync(&self, fence: Self::Fence, flags: u32, timeout: i32) -> u32 {
         let fences = self.fences.borrow();
         let raw_fence = fences.get_unchecked(fence);

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -2614,6 +2614,14 @@ impl HasContext for Context {
         }
     }
 
+    unsafe fn check_named_framebuffer_status(
+        &self,
+        _framebuffer: Option<Self::Framebuffer>,
+        _target: u32,
+    ) -> u32 {
+        panic!("Named framebuffers are not supported");
+    }
+
     unsafe fn clear_buffer_i32_slice(&self, target: u32, draw_buffer: u32, values: &[i32]) {
         match self.raw {
             RawRenderingContext::WebGl1(ref _gl) => {


### PR DESCRIPTION
Adds the following Named Framebuffer APIs

- [`glClearNamedFramebuffer`](https://registry.khronos.org/OpenGL-Refpages/gl4/html/glClearBuffer.xhtml)
- [`glNamedFramebufferRenderbuffer`](https://registry.khronos.org/OpenGL-Refpages/gl4/html/glFramebufferRenderbuffer.xhtml)
- [`glNamedFramebufferTextureLayer`](https://registry.khronos.org/OpenGL-Refpages/gl4/html/glFramebufferTextureLayer.xhtml)
- [`glNamedFramebufferTexture`](https://registry.khronos.org/OpenGL-Refpages/gl4/html/glFramebufferTexture.xhtml)
- [`glBlitNamedFramebuffer`](https://registry.khronos.org/OpenGL-Refpages/gl4/html/glBlitFramebuffer.xhtml)
- [`glNamedFramebufferReadBuffer`](https://registry.khronos.org/OpenGL-Refpages/gl4/html/glReadBuffer.xhtml)
- [`glNamedFramebufferDrawBuffer`](https://registry.khronos.org/OpenGL-Refpages/gl4/html/glDrawBuffer.xhtml)
- [`glCreateFramebuffers`](https://registry.khronos.org/OpenGL-Refpages/gl4/html/glCreateFramebuffers.xhtml) as `create_named_framebuffer`
- [`glNamedFramebufferDrawBuffers`](https://registry.khronos.org/OpenGL-Refpages/gl4/html/glDrawBuffers.xhtml)

Also adds the following APIs

- [`glGetFramebufferAttachmentParameter`](https://registry.khronos.org/OpenGL-Refpages/gl4/html/glGetFramebufferAttachmentParameter.xhtml)
- [`glGetFramebufferParameter`](https://registry.khronos.org/OpenGL-Refpages/gl4/html/glGetFramebufferParameter.xhtml)
- [`glCreateVertexArrays`](https://registry.khronos.org/OpenGL-Refpages/gl4/html/glCreateVertexArrays.xhtml) as `create_named_vertex_array`