### PR TITLE
add aliases for get_parameter_* functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -789,18 +789,25 @@ pub trait HasContext: __private::Sealed {
 
     unsafe fn get_buffer_parameter_i32(&self, target: u32, parameter: u32) -> i32;
 
+    #[doc(alias = "glGetIntegerv")]
     unsafe fn get_parameter_i32(&self, parameter: u32) -> i32;
 
+    #[doc(alias = "glGetIntegerv")]
     unsafe fn get_parameter_i32_slice(&self, parameter: u32, out: &mut [i32]);
 
+    #[doc(alias = "glGetFloatv")]
     unsafe fn get_parameter_f32(&self, parameter: u32) -> f32;
 
+    #[doc(alias = "glGetFloatv")]
     unsafe fn get_parameter_f32_slice(&self, parameter: u32, out: &mut [f32]);
 
+    #[doc(alias = "glGetIntegeri_v")]
     unsafe fn get_parameter_indexed_i32(&self, parameter: u32, index: u32) -> i32;
 
+    #[doc(alias = "glGetStringi")]
     unsafe fn get_parameter_indexed_string(&self, parameter: u32, index: u32) -> String;
 
+    #[doc(alias = "glGetString")]
     unsafe fn get_parameter_string(&self, parameter: u32) -> String;
 
     unsafe fn get_active_uniform_block_parameter_i32(


### PR DESCRIPTION
Usually glow's names line up pretty well with OpenGL names, but I had to ask around to find out what the glow equivalents of `glGetIntegerv` and friends are. This PR adds some doc aliases to make the functions easier to discover.