### PR TITLE
clear_depth, depth_range with auto select the best function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -536,7 +536,7 @@ pub trait HasContext: __private::Sealed {
 
     unsafe fn clear_color(&self, red: f32, green: f32, blue: f32, alpha: f32);
 
-    unsafe fn supports_f64_precision() -> bool;
+    unsafe fn supports_f64_precision(&self) -> bool;
 
     unsafe fn clear_depth_f64(&self, depth: f64);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -542,6 +542,8 @@ pub trait HasContext: __private::Sealed {
 
     unsafe fn clear_depth_f32(&self, depth: f32);
 
+    unsafe fn clear_depth(&self, depth: f64);
+
     unsafe fn clear_stencil(&self, stencil: i32);
 
     unsafe fn clear(&self, mask: u32);
@@ -1470,6 +1472,8 @@ pub trait HasContext: __private::Sealed {
     unsafe fn depth_range_f32(&self, near: f32, far: f32);
 
     unsafe fn depth_range_f64(&self, near: f64, far: f64);
+
+    unsafe fn depth_range(&self, near: f64, far: f64);
 
     unsafe fn depth_range_f64_slice(&self, first: u32, count: i32, values: &[[f64; 2]]);
 

--- a/src/native.rs
+++ b/src/native.rs
@@ -1236,9 +1236,8 @@ impl HasContext for Context {
         gl.ClearColor(red, green, blue, alpha);
     }
 
-    unsafe fn supports_f64_precision() -> bool {
-        // TODO: Handle OpenGL ES
-        true
+    unsafe fn supports_f64_precision(&self) -> bool {
+        !self.version.is_embedded
     }
 
     unsafe fn clear_depth_f64(&self, depth: f64) {
@@ -1252,7 +1251,7 @@ impl HasContext for Context {
     }
 
     unsafe fn clear_depth(&self, depth: f64) {
-        if !self.version.is_embedded {
+        if self.supports_f64_precision() {
             self.clear_depth_f64(depth);
         } else {
             self.clear_depth_f32(depth as f32);
@@ -3275,7 +3274,7 @@ impl HasContext for Context {
     }
 
     unsafe fn depth_range(&self, near: f64, far: f64) {
-        if !self.version.is_embedded {
+        if self.supports_f64_precision() {
             self.depth_range_f64(near, far);
         } else {
             self.depth_range_f32(near as f32, far as f32);

--- a/src/native.rs
+++ b/src/native.rs
@@ -1251,6 +1251,14 @@ impl HasContext for Context {
         gl.ClearDepthf(depth);
     }
 
+    unsafe fn clear_depth(&self, depth: f64) {
+        if !self.version.is_embedded {
+            self.clear_depth_f64(depth);
+        } else {
+            self.clear_depth_f32(depth as f32);
+        }
+    }
+
     unsafe fn clear_stencil(&self, stencil: i32) {
         let gl = &self.raw;
         gl.ClearStencil(stencil);
@@ -3264,6 +3272,14 @@ impl HasContext for Context {
     unsafe fn depth_range_f64(&self, near: f64, far: f64) {
         let gl = &self.raw;
         gl.DepthRange(near, far);
+    }
+
+    unsafe fn depth_range(&self, near: f64, far: f64) {
+        if !self.version.is_embedded {
+            self.depth_range_f64(near, far);
+        } else {
+            self.depth_range_f32(near as f32, far as f32);
+        }
     }
 
     unsafe fn depth_range_f64_slice(&self, first: u32, count: i32, values: &[[f64; 2]]) {

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -2546,7 +2546,7 @@ impl HasContext for Context {
         }
     }
 
-    unsafe fn supports_f64_precision() -> bool {
+    unsafe fn supports_f64_precision(&self) -> bool {
         false
     }
 

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -2561,6 +2561,10 @@ impl HasContext for Context {
         }
     }
 
+    unsafe fn clear_depth(&self, depth: f64) {
+        self.clear_depth_f32(depth as f32);
+    }
+
     unsafe fn clear_stencil(&self, stencil: i32) {
         match self.raw {
             RawRenderingContext::WebGl1(ref gl) => gl.clear_stencil(stencil),
@@ -4889,6 +4893,10 @@ impl HasContext for Context {
 
     unsafe fn depth_range_f64(&self, _near: f64, _far: f64) {
         panic!("Depth range with 64-bit float values is not supported");
+    }
+
+    unsafe fn depth_range(&self, near: f64, far: f64) {
+        self.depth_range_f32(near as f32, far as f32)
     }
 
     unsafe fn depth_range_f64_slice(&self, _first: u32, _count: i32, _values: &[[f64; 2]]) {


### PR DESCRIPTION
This would be useful for servo as sparkle also did this: https://github.com/servo/sparkle/blob/a61f94fff95d29e93721cdbfc4b5dde8671a6970/src/lib.rs#L736. [All OpenGL versions supports f64 variant, but only 4.1>= supports f32 variant](https://docs.gl/gl4/glClearDepth), while [GLES supports only f32 variant](https://docs.gl/es3/glClearDepthf)

Second commit uses `supports_f64_precision` for auto selection and fixes `supports_f64_precision` on native for GLES to return false, but it's breaking change (as it needs &self now), although I did not find any users of it on whole GitHub.