### PR TITLE
add components_per_format, bytes_per_type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1829,6 +1829,10 @@ pub fn bytes_per_type(pixel_type: u32) -> usize {
     }
 }
 
+pub fn compute_size(width: i32, height: i32, format: u32, pixel_type: u32) -> usize {
+    width as usize * height as usize * components_per_format(format) * bytes_per_type(pixel_type)
+}
+
 pub const ACTIVE_ATOMIC_COUNTER_BUFFERS: u32 = 0x92D9;
 
 pub const ACTIVE_ATTRIBUTES: u32 = 0x8B89;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1803,6 +1803,32 @@ pub trait HasContext: __private::Sealed {
     unsafe fn max_shader_compiler_threads(&self, count: u32);
 }
 
+/// Returns number of components used by format
+pub fn components_per_format(format: u32) -> usize {
+    match format {
+        RED | GREEN | BLUE => 1,
+        RED_INTEGER | GREEN_INTEGER | BLUE_INTEGER => 1,
+        ALPHA | LUMINANCE | DEPTH_COMPONENT => 1,
+        RG | LUMINANCE_ALPHA => 2,
+        RGB | BGR => 3,
+        RGBA | BGRA => 4,
+        _ => panic!("unsupported format: {:?}", format),
+    }
+}
+
+/// Returns number of bytes used by pixel type (in one component)
+pub fn bytes_per_type(pixel_type: u32) -> usize {
+    // per https://www.khronos.org/opengl/wiki/Pixel_Transfer#Pixel_type
+    match pixel_type {
+        BYTE | UNSIGNED_BYTE => 1,
+        SHORT | UNSIGNED_SHORT => 2,
+        INT | UNSIGNED_INT => 4,
+        HALF_FLOAT | HALF_FLOAT_OES => 2,
+        FLOAT => 4,
+        _ => panic!("unsupported pixel type: {:?}", pixel_type),
+    }
+}
+
 pub const ACTIVE_ATOMIC_COUNTER_BUFFERS: u32 = 0x92D9;
 
 pub const ACTIVE_ATTRIBUTES: u32 = 0x8B89;


### PR DESCRIPTION
read_pixels defines `pixels len: COMPSIZE(format,type,width,height)`, and this PR provides such function.

based on: https://github.com/servo/sparkle/blob/a61f94fff95d29e93721cdbfc4b5dde8671a6970/src/lib.rs#L2636