### PR TITLE
Use `PixelUnpackData` in tex_image_{1,2,3}d

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1094,7 +1094,7 @@ pub trait HasContext: __private::Sealed {
         border: i32,
         format: u32,
         ty: u32,
-        pixels: Option<&[u8]>,
+        pixels: PixelUnpackData,
     );
 
     unsafe fn tex_image_2d_multisample(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1130,7 +1130,7 @@ pub trait HasContext: __private::Sealed {
         border: i32,
         format: u32,
         ty: u32,
-        pixels: Option<&[u8]>,
+        pixels: PixelUnpackData,
     );
 
     unsafe fn compressed_tex_image_3d(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1070,7 +1070,7 @@ pub trait HasContext: __private::Sealed {
         border: i32,
         format: u32,
         ty: u32,
-        pixels: Option<&[u8]>,
+        pixels: PixelUnpackData,
     );
 
     unsafe fn compressed_tex_image_1d(

--- a/src/native.rs
+++ b/src/native.rs
@@ -2435,7 +2435,7 @@ impl HasContext for Context {
         border: i32,
         format: u32,
         ty: u32,
-        pixels: Option<&[u8]>,
+        pixels: PixelUnpackData,
     ) {
         let gl = &self.raw;
         gl.TexImage1D(
@@ -2446,7 +2446,10 @@ impl HasContext for Context {
             border,
             format,
             ty,
-            pixels.map(|p| p.as_ptr()).unwrap_or(std::ptr::null()) as *const std::ffi::c_void,
+            match pixels {
+                PixelUnpackData::BufferOffset(offset) => offset as *const std::ffi::c_void,
+                PixelUnpackData::Slice(data) => data.as_ptr() as *const std::ffi::c_void,
+            },
         );
     }
 

--- a/src/native.rs
+++ b/src/native.rs
@@ -2482,7 +2482,7 @@ impl HasContext for Context {
         border: i32,
         format: u32,
         ty: u32,
-        pixels: Option<&[u8]>,
+        pixels: PixelUnpackData,
     ) {
         let gl = &self.raw;
         gl.TexImage2D(
@@ -2494,7 +2494,10 @@ impl HasContext for Context {
             border,
             format,
             ty,
-            pixels.map(|p| p.as_ptr()).unwrap_or(std::ptr::null()) as *const std::ffi::c_void,
+            match pixels {
+                PixelUnpackData::BufferOffset(offset) => offset as *const std::ffi::c_void,
+                PixelUnpackData::Slice(data) => data.as_ptr() as *const std::ffi::c_void,
+            },
         );
     }
 

--- a/src/native.rs
+++ b/src/native.rs
@@ -2559,7 +2559,7 @@ impl HasContext for Context {
         border: i32,
         format: u32,
         ty: u32,
-        pixels: Option<&[u8]>,
+        pixels: PixelUnpackData,
     ) {
         let gl = &self.raw;
         gl.TexImage3D(
@@ -2572,7 +2572,10 @@ impl HasContext for Context {
             border,
             format,
             ty,
-            pixels.map(|p| p.as_ptr()).unwrap_or(std::ptr::null()) as *const std::ffi::c_void,
+            match pixels {
+                PixelUnpackData::BufferOffset(offset) => offset as *const std::ffi::c_void,
+                PixelUnpackData::Slice(data) => data.as_ptr() as *const std::ffi::c_void,
+            },
         );
     }
 

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -3940,7 +3940,7 @@ impl HasContext for Context {
         _border: i32,
         _format: u32,
         _ty: u32,
-        _pixels: Option<&[u8]>,
+        _pixels: PixelUnpackData,
     ) {
         panic!("Tex image 1D is not supported");
     }


### PR DESCRIPTION
Although we lost explicit None case with this I have WIP to fix this everywhere: https://github.com/sagudev/glow/commit/1378d85b636c04141e88b4b74977894d646b34e0 (`Option` is put into `PixelUnpackData::Slice` variant because it matches webgl better, alternative would be to have `PixelUnpackData::None` variant or do nothing as we can already express this as `PixelUnpackData::BufferOffset(0)`).