### PR TITLE
Pixel(Un)PackData with None

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,12 +108,12 @@ pub struct DebugMessageLogEntry {
 
 pub enum PixelPackData<'a> {
     BufferOffset(u32),
-    Slice(&'a mut [u8]),
+    Slice(Option<&'a mut [u8]>),
 }
 
 pub enum PixelUnpackData<'a> {
     BufferOffset(u32),
-    Slice(&'a [u8]),
+    Slice(Option<&'a [u8]>),
 }
 
 pub enum CompressedPixelUnpackData<'a> {

--- a/src/native.rs
+++ b/src/native.rs
@@ -416,7 +416,8 @@ impl HasContext for Context {
             ty,
             match pixels {
                 PixelPackData::BufferOffset(offset) => offset as *mut std::ffi::c_void,
-                PixelPackData::Slice(data) => data.as_mut_ptr() as *mut std::ffi::c_void,
+                PixelPackData::Slice(Some(data)) => data.as_mut_ptr() as *mut std::ffi::c_void,
+                PixelPackData::Slice(None) => ptr::null_mut(),
             },
         );
     }
@@ -2507,7 +2508,8 @@ impl HasContext for Context {
             ty,
             match pixels {
                 PixelUnpackData::BufferOffset(offset) => offset as *const std::ffi::c_void,
-                PixelUnpackData::Slice(data) => data.as_ptr() as *const std::ffi::c_void,
+                PixelUnpackData::Slice(Some(data)) => data.as_ptr() as *const std::ffi::c_void,
+                PixelUnpackData::Slice(None) => ptr::null(),
             },
         );
     }
@@ -2558,7 +2560,8 @@ impl HasContext for Context {
             ty,
             match pixels {
                 PixelUnpackData::BufferOffset(offset) => offset as *const std::ffi::c_void,
-                PixelUnpackData::Slice(data) => data.as_ptr() as *const std::ffi::c_void,
+                PixelUnpackData::Slice(Some(data)) => data.as_ptr() as *const std::ffi::c_void,
+                PixelUnpackData::Slice(None) => ptr::null(),
             },
         );
     }
@@ -2633,7 +2636,8 @@ impl HasContext for Context {
             ty,
             match pixels {
                 PixelUnpackData::BufferOffset(offset) => offset as *const std::ffi::c_void,
-                PixelUnpackData::Slice(data) => data.as_ptr() as *const std::ffi::c_void,
+                PixelUnpackData::Slice(Some(data)) => data.as_ptr() as *const std::ffi::c_void,
+                PixelUnpackData::Slice(None) => ptr::null(),
             },
         );
     }
@@ -3314,7 +3318,8 @@ impl HasContext for Context {
             ty,
             match pixels {
                 PixelUnpackData::BufferOffset(offset) => offset as *const std::ffi::c_void,
-                PixelUnpackData::Slice(data) => data.as_ptr() as *const std::ffi::c_void,
+                PixelUnpackData::Slice(Some(data)) => data.as_ptr() as *const std::ffi::c_void,
+                PixelUnpackData::Slice(None) => ptr::null(),
             },
         );
     }
@@ -3343,7 +3348,8 @@ impl HasContext for Context {
             ty,
             match pixels {
                 PixelUnpackData::BufferOffset(offset) => offset as *const std::ffi::c_void,
-                PixelUnpackData::Slice(data) => data.as_ptr() as *const std::ffi::c_void,
+                PixelUnpackData::Slice(Some(data)) => data.as_ptr() as *const std::ffi::c_void,
+                PixelUnpackData::Slice(None) => ptr::null(),
             },
         );
     }
@@ -3403,7 +3409,8 @@ impl HasContext for Context {
             ty,
             match pixels {
                 PixelUnpackData::BufferOffset(offset) => offset as *const std::ffi::c_void,
-                PixelUnpackData::Slice(data) => data.as_ptr() as *const std::ffi::c_void,
+                PixelUnpackData::Slice(Some(data)) => data.as_ptr() as *const std::ffi::c_void,
+                PixelUnpackData::Slice(None) => ptr::null(),
             },
         );
     }
@@ -3436,7 +3443,8 @@ impl HasContext for Context {
             ty,
             match pixels {
                 PixelUnpackData::BufferOffset(offset) => offset as *const std::ffi::c_void,
-                PixelUnpackData::Slice(data) => data.as_ptr() as *const std::ffi::c_void,
+                PixelUnpackData::Slice(Some(data)) => data.as_ptr() as *const std::ffi::c_void,
+                PixelUnpackData::Slice(None) => ptr::null(),
             },
         );
     }
@@ -4191,7 +4199,8 @@ impl HasContext for Context {
             gltype,
             match pixels {
                 PixelPackData::BufferOffset(offset) => offset as *mut std::ffi::c_void,
-                PixelPackData::Slice(data) => data.as_mut_ptr() as *mut std::ffi::c_void,
+                PixelPackData::Slice(Some(data)) => data.as_mut_ptr() as *mut std::ffi::c_void,
+                PixelPackData::Slice(None) => ptr::null_mut(),
             },
         );
     }

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -3995,7 +3995,7 @@ impl HasContext for Context {
                 match pixels {
                     PixelUnpackData::BufferOffset(_offset) => panic!("Tex image 2D with offset is not supported"),
                     PixelUnpackData::Slice(data) => {
-                        let data = texture_data_view(ty, data);
+                        let data = data.map(|data| texture_data_view(ty, data));
                         gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_array_buffer_view(
                             target,
                             level,
@@ -4005,7 +4005,7 @@ impl HasContext for Context {
                             border,
                             format,
                             ty,
-                            Some(&data),
+                            data.as_ref(),
                         )
                     }
                 }
@@ -4026,7 +4026,7 @@ impl HasContext for Context {
                             offset as i32,
                         ),
                     PixelUnpackData::Slice(data) => {
-                        let data = texture_data_view(ty, data);
+                        let data = data.map(|data| texture_data_view(ty, data));
                         gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_array_buffer_view(
                             target,
                             level,
@@ -4036,7 +4036,7 @@ impl HasContext for Context {
                             border,
                             format,
                             ty,
-                            Some(&data),
+                            data.as_ref(),
                         )
                     }
                 }
@@ -4123,7 +4123,7 @@ impl HasContext for Context {
                         offset as i32,
                     ),
                     PixelUnpackData::Slice(data) => {
-                        let data = texture_data_view(ty, data);
+                        let data = data.map(|data| texture_data_view(ty, data));
                         gl.tex_image_3d_with_opt_array_buffer_view(
                             target,
                             level,
@@ -4134,7 +4134,7 @@ impl HasContext for Context {
                             depth,
                             format,
                             ty,
-                            Some(&data),
+                            data.as_ref(),
                         )
                     }
                 }
@@ -4918,9 +4918,9 @@ impl HasContext for Context {
                         panic!("Sub image 2D pixel buffer offset is not supported");
                     }
                     PixelUnpackData::Slice(data) => {
-                        let data = texture_data_view(ty, data);
+                        let data = data.map(|data| texture_data_view(ty, data));
                         gl.tex_sub_image_2d_with_i32_and_i32_and_u32_and_type_and_opt_array_buffer_view(
-                            target, level, x_offset, y_offset, width, height, format, ty, Some(&data),
+                            target, level, x_offset, y_offset, width, height, format, ty, data.as_ref(),
                         )
                     }
                 }
@@ -4941,9 +4941,9 @@ impl HasContext for Context {
                             offset as i32,
                         ),
                     PixelUnpackData::Slice(data) => {
-                        let data = texture_data_view(ty, data);
+                        let data = data.map(|data| texture_data_view(ty, data));
                         gl.tex_sub_image_2d_with_i32_and_i32_and_u32_and_type_and_opt_array_buffer_view(
-                            target, level, x_offset, y_offset, width, height, format, ty, Some(&data),
+                            target, level, x_offset, y_offset, width, height, format, ty, data.as_ref()
                         )
                     }
                 }
@@ -5063,8 +5063,8 @@ impl HasContext for Context {
                         ty,
                         offset as i32,
                     ),
-                    PixelUnpackData::Slice(slice) => {
-                        let slice = texture_data_view(ty, slice);
+                    PixelUnpackData::Slice(data) => {
+                        let data = data.map(|data| texture_data_view(ty, data));
                         gl.tex_sub_image_3d_with_opt_array_buffer_view(
                             target,
                             level,
@@ -5076,7 +5076,7 @@ impl HasContext for Context {
                             depth,
                             format,
                             ty,
-                            Some(&slice),
+                            data.as_ref(),
                         )
                     }
                 }
@@ -5735,8 +5735,8 @@ impl HasContext for Context {
                     .read_pixels_with_i32(x, y, width, height, format, gltype, offset as i32)
                     .unwrap(),
             },
-            PixelPackData::Slice(bytes) => {
-                let data = texture_data_view(gltype, bytes);
+            PixelPackData::Slice(data) => {
+                let data = data.map(|data| texture_data_view(gltype, data));
                 match self.raw {
                     RawRenderingContext::WebGl1(ref gl) => gl
                         .read_pixels_with_opt_array_buffer_view(
@@ -5746,7 +5746,7 @@ impl HasContext for Context {
                             height,
                             format,
                             gltype,
-                            Some(&data),
+                            data.as_ref(),
                         )
                         .unwrap(),
                     RawRenderingContext::WebGl2(ref gl) => gl
@@ -5757,7 +5757,7 @@ impl HasContext for Context {
                             height,
                             format,
                             gltype,
-                            Some(&data),
+                            data.as_ref(),
                         )
                         .unwrap(),
                 }


### PR DESCRIPTION
As announced in https://github.com/grovesNL/glow/pull/322#issue-2629596296.

`Option` is put into `PixelUnpackData::Slice` variant because it matches webgl better.

Alternatives:
- `PixelUnpackData::None` variant
- ~~do nothing as we can already express this as `PixelUnpackData::BufferOffset(0)`~~ actually this is not true, there is no way to pass null/0 in WebGL 1 context as BufferOffset variants are not supported by spec (glow panics) but null value is supported by spec (for example see `tex_image_2d`).