### PR TITLE
Release 0.16.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glow"
-version = "0.15.0"
+version = "0.16.0"
 description = "GL on Whatever: a set of bindings to run GL (Open GL, OpenGL ES, and WebGL) anywhere, and avoid target-specific code."
 authors = [
   "Joshua Groves <josh@joshgroves.com>",


### PR DESCRIPTION
There were some breaking changes since last release. Only needs `cargo publish`.