### PR TITLE
Support `GLboolean` return type of `WebGL2RenderingContext.getQueryParameter()`

### DIFF
--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -5869,11 +5869,13 @@ impl HasContext for Context {
         let raw_query = queries.get_unchecked(query);
         match self.raw {
             RawRenderingContext::WebGl1(ref _gl) => panic!("Query objects are not supported"),
-            RawRenderingContext::WebGl2(ref gl) => gl
-                .get_query_parameter(raw_query, parameter)
-                .as_f64()
-                .map(|v| v as u32)
-                .unwrap_or(0),
+            RawRenderingContext::WebGl2(ref gl) => {
+                let v = gl.get_query_parameter(raw_query, parameter);
+                v.as_f64()
+                    .map(|v| v as u32)
+                    .or_else(|| v.as_bool().map(|v| v as u32))
+                    .unwrap_or(0)
+            }
         }
     }
 


### PR DESCRIPTION
`WebGL2RenderingContext.getQueryParameter()` returns `GLboolean` for `QUERY_RESULT_AVAILABLE` (see [documentation](https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext/getQueryParameter)).  This PR adds support for mapping from `GLboolean` to `u32` in `get_query_parameter_u32()`.

As an alternative, I was considering to add `get_query_parameter_bool()`, but then realized that no other target has that method.