### PR TITLE
add get_query_parameter_u64

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1853,6 +1853,8 @@ pub trait HasContext: __private::Sealed {
 
     unsafe fn get_query_parameter_u32(&self, query: Self::Query, parameter: u32) -> u32;
 
+    unsafe fn get_query_parameter_u64(&self, query: Self::Query, parameter: u32) -> u64;
+
     unsafe fn get_query_parameter_u64_with_offset(
         &self,
         query: Self::Query,

--- a/src/native.rs
+++ b/src/native.rs
@@ -4243,6 +4243,17 @@ impl HasContext for Context {
         value
     }
 
+    unsafe fn get_query_parameter_u64(&self, query: Self::Query, parameter: u32) -> u64 {
+        let gl = &self.raw;
+        let mut value = 0;
+        if gl.GetQueryBufferObjectiv_is_loaded() {
+            gl.GetQueryObjectui64v(query.0.get(), parameter, &mut value);
+        } else {
+            gl.GetQueryObjectui64vEXT(query.0.get(), parameter, &mut value);
+        }
+        value
+    }
+
     unsafe fn get_query_parameter_u64_with_offset(
         &self,
         query: Self::Query,

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -5889,6 +5889,19 @@ impl HasContext for Context {
         }
     }
 
+    unsafe fn get_query_parameter_u64(&self, query: Self::Query, parameter: u32) -> u64 {
+        let queries = self.queries.borrow();
+        let raw_query = queries.get_unchecked(query);
+        match self.raw {
+            RawRenderingContext::WebGl1(ref _gl) => panic!("Query objects are not supported"),
+            RawRenderingContext::WebGl2(ref gl) => gl
+                .get_query_parameter(raw_query, parameter)
+                .as_f64()
+                .map(|v| v as u64)
+                .unwrap_or(0),
+        }
+    }
+
     unsafe fn get_query_parameter_u64_with_offset(
         &self,
         _query: Self::Query,


### PR DESCRIPTION
I haven't tested the WebGL implementation of this function because I don't know how - I'm relying on the CI to tell me if it's right. From my reading, WebGL2's `getQueryParameter` always returns a 32-bit int, so this implementation of `get_query_parameter_u64` wouldn't return 64 bits worth of data on web, just a u32 converted to a u64. I think that's reasonable, but I'm not sure if that's in the spirit of this library.