### PR TITLE
Implemented get_sampler_parameter_f32_slice.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1110,6 +1110,8 @@ pub trait HasContext: __private::Sealed {
 
     unsafe fn get_sampler_parameter_f32(&self, sampler: Self::Sampler, name: u32) -> f32;
 
+    unsafe fn get_sampler_parameter_f32_slice(&self, sampler: Self::Sampler, name: u32, out: &mut [f32] );
+
     unsafe fn generate_mipmap(&self, target: u32);
 
     unsafe fn generate_texture_mipmap(&self, texture: Self::Texture);

--- a/src/native.rs
+++ b/src/native.rs
@@ -2487,6 +2487,11 @@ impl HasContext for Context {
         value
     }
 
+    unsafe fn get_sampler_parameter_f32_slice(&self, sampler: Self::Sampler, name: u32, out: &mut [f32] ) {
+        let gl = &self.raw;
+        gl.GetSamplerParameterfv(sampler.0.get(), name, out.as_mut_ptr());
+    }
+
     unsafe fn generate_mipmap(&self, target: u32) {
         let gl = &self.raw;
         gl.GenerateMipmap(target);

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -3958,6 +3958,11 @@ impl HasContext for Context {
         .unwrap_or(0.)
     }
 
+    unsafe fn get_sampler_parameter_f32_slice(&self, sampler: Self::Sampler, name: u32, out: &mut [f32]) {
+        // There is no current WebGL API to access this like there is for C
+        panic!("Sampler parameter for `f32_slice` is not supported")
+    }
+
     unsafe fn generate_mipmap(&self, target: u32) {
         match self.raw {
             RawRenderingContext::WebGl1(ref gl) => {


### PR DESCRIPTION
Solves #342. It is straight forward except for the fact that, to the best of my knowledge, this isn't supported by WebGL API, so it just panics in that case.

My usage case is copying the border colour of a sampler object to another.