### PR TITLE
Add missing glGetTexLevelParameterXX and glGetTextureLevelParameterXX functions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,9 +98,3 @@ features = [
   "WebglLoseContext",
   "OvrMultiview2",
 ]
-
-[workspace]
-members = [
-  "examples/hello",
-  "examples/howto",
-]

--- a/src/gl46.rs
+++ b/src/gl46.rs
@@ -3,6 +3,7 @@
 #![allow(bad_style)]
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
+#![allow(warnings)]
 
 //! Bindings to Gl 4.6
 //!
@@ -4840,9 +4841,11 @@ unsafe fn call_atomic_ptr_15arg<Ret, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O
 
 pub use struct_commands::*;
 pub mod struct_commands {
+    #![allow(clippy::all)]
     //! Contains the [`GlFns`] type for using the struct GL loader.
     use super::*;
     impl GlFns {
+        #![allow(clippy::all)]
         /// Constructs a new struct with all pointers loaded by the `get_proc_address` given.
         pub unsafe fn load_with<F>(mut get_proc_address: F) -> Self
         where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -959,6 +959,24 @@ pub trait HasContext: __private::Sealed {
 
     unsafe fn get_tex_parameter_f32(&self, target: u32, parameter: u32) -> f32;
 
+    unsafe fn get_texture_level_parameter_i32(
+        &self,
+        texture: Self::Texture,
+        level: i32,
+        parameter: u32,
+    ) -> i32;
+
+    unsafe fn get_texture_level_parameter_f32(
+        &self,
+        texture: Self::Texture,
+        level: i32,
+        parameter: u32,
+    ) -> f32;
+
+    unsafe fn get_tex_level_parameter_i32(&self, target: u32, level: i32, parameter: u32) -> i32;
+
+    unsafe fn get_tex_level_parameter_f32(&self, target: u32, level: i32, parameter: u32) -> f32;
+
     unsafe fn get_buffer_parameter_i32(&self, target: u32, parameter: u32) -> i32;
 
     #[doc(alias = "glGetBooleanv")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![allow(clippy::unreadable_literal)]
 #![allow(clippy::missing_safety_doc)]
 #![allow(clippy::pedantic)] // For anyone using pedantic and a source dep, this is needed
+#![allow(clippy::all)]
 
 use core::fmt::Debug;
 use core::hash::Hash;

--- a/src/native.rs
+++ b/src/native.rs
@@ -4536,6 +4536,44 @@ impl HasContext for Context {
             result.as_mut_ptr(),
         )
     }
+
+    unsafe fn get_texture_level_parameter_i32(
+        &self,
+        texture: Self::Texture,
+        level: i32,
+        parameter: u32,
+    ) -> i32 {
+        let gl = &self.raw;
+        let mut value = 0;
+        gl.GetTextureLevelParameteriv(texture.0.get(), level, parameter, &mut value);
+        value
+    }
+
+    unsafe fn get_texture_level_parameter_f32(
+        &self,
+        texture: Self::Texture,
+        level: i32,
+        parameter: u32,
+    ) -> f32 {
+        let gl = &self.raw;
+        let mut value = 0.0;
+        gl.GetTextureLevelParameterfv(texture.0.get(), level, parameter, &mut value);
+        value
+    }
+
+    unsafe fn get_tex_level_parameter_i32(&self, target: u32, level: i32, parameter: u32) -> i32 {
+        let gl = &self.raw;
+        let mut value = 0;
+        gl.GetTexLevelParameteriv(target, level, parameter, &mut value);
+        value
+    }
+
+    unsafe fn get_tex_level_parameter_f32(&self, target: u32, level: i32, parameter: u32) -> f32 {
+        let gl = &self.raw;
+        let mut value = 0.0;
+        gl.GetTexLevelParameterfv(target, level, parameter, &mut value);
+        value
+    }
 }
 
 impl Drop for Context {


### PR DESCRIPTION
Was trying to use these APIs and I couldn't find it in the docs and code. Added the missing bindings.

https://registry.khronos.org/OpenGL-Refpages/gl4/html/glGetTexLevelParameter.xhtml

I don't have formal tests, but it seems to be working on the project I'm working on.

Tried to match the form of the other APIs. Please let me know if you need any changes. Thanks!