### PR TITLE
Add glGetTexLevelParameterXX and glGetTextureLevelParameterXX functions.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -959,6 +959,24 @@ pub trait HasContext: __private::Sealed {
 
     unsafe fn get_tex_parameter_f32(&self, target: u32, parameter: u32) -> f32;
 
+    unsafe fn get_texture_level_parameter_i32(
+        &self,
+        texture: Self::Texture,
+        level: i32,
+        parameter: u32,
+    ) -> i32;
+
+    unsafe fn get_texture_level_parameter_f32(
+        &self,
+        texture: Self::Texture,
+        level: i32,
+        parameter: u32,
+    ) -> f32;
+
+    unsafe fn get_tex_level_parameter_i32(&self, target: u32, level: i32, parameter: u32) -> i32;
+
+    unsafe fn get_tex_level_parameter_f32(&self, target: u32, level: i32, parameter: u32) -> f32;
+
     unsafe fn get_buffer_parameter_i32(&self, target: u32, parameter: u32) -> i32;
 
     #[doc(alias = "glGetBooleanv")]

--- a/src/native.rs
+++ b/src/native.rs
@@ -4536,6 +4536,44 @@ impl HasContext for Context {
             result.as_mut_ptr(),
         )
     }
+
+    unsafe fn get_texture_level_parameter_i32(
+        &self,
+        texture: Self::Texture,
+        level: i32,
+        parameter: u32,
+    ) -> i32 {
+        let gl = &self.raw;
+        let mut value = 0;
+        gl.GetTextureLevelParameteriv(texture.0.get(), level, parameter, &mut value);
+        value
+    }
+
+    unsafe fn get_texture_level_parameter_f32(
+        &self,
+        texture: Self::Texture,
+        level: i32,
+        parameter: u32,
+    ) -> f32 {
+        let gl = &self.raw;
+        let mut value = 0.0;
+        gl.GetTextureLevelParameterfv(texture.0.get(), level, parameter, &mut value);
+        value
+    }
+
+    unsafe fn get_tex_level_parameter_i32(&self, target: u32, level: i32, parameter: u32) -> i32 {
+        let gl = &self.raw;
+        let mut value = 0;
+        gl.GetTexLevelParameteriv(target, level, parameter, &mut value);
+        value
+    }
+
+    unsafe fn get_tex_level_parameter_f32(&self, target: u32, level: i32, parameter: u32) -> f32 {
+        let gl = &self.raw;
+        let mut value = 0.0;
+        gl.GetTexLevelParameterfv(target, level, parameter, &mut value);
+        value
+    }
 }
 
 impl Drop for Context {


### PR DESCRIPTION
Was trying to use these APIs and I couldn't find it in the docs and code. Added the missing bindings.

https://registry.khronos.org/OpenGL-Refpages/gl4/html/glGetTexLevelParameter.xhtml

I don't have formal tests, but it seems to be working on the project I'm working on.

Tried to match the form of the other APIs. Please let me know if you need any changes. Thanks!
