### PR TITLE
Fix native get_query_parameter_*

### DIFF
--- a/src/native.rs
+++ b/src/native.rs
@@ -4380,7 +4380,7 @@ impl HasContext for Context {
     unsafe fn get_query_parameter_u32(&self, query: Self::Query, parameter: u32) -> u32 {
         let gl = &self.raw;
         let mut value = 0;
-        if gl.GetQueryBufferObjectiv_is_loaded() {
+        if gl.GetQueryObjectuiv_is_loaded() {
             gl.GetQueryObjectuiv(query.0.get(), parameter, &mut value);
         } else {
             gl.GetQueryObjectuivEXT(query.0.get(), parameter, &mut value);
@@ -4391,7 +4391,7 @@ impl HasContext for Context {
     unsafe fn get_query_parameter_u64(&self, query: Self::Query, parameter: u32) -> u64 {
         let gl = &self.raw;
         let mut value = 0;
-        if gl.GetQueryBufferObjectiv_is_loaded() {
+        if gl.GetQueryObjectui64v_is_loaded() {
             gl.GetQueryObjectui64v(query.0.get(), parameter, &mut value);
         } else {
             gl.GetQueryObjectui64vEXT(query.0.get(), parameter, &mut value);


### PR DESCRIPTION
`get_query_parameter_u32`/`get_query_parameter_u64` incorrectly used `GetQueryBufferObjectiv_is_loaded` as a check instead of their respective `*_is_loaded` calls.