### PR TITLE
Fix timer panic for macOS

### DIFF
--- a/src/native.rs
+++ b/src/native.rs
@@ -4380,7 +4380,7 @@ impl HasContext for Context {
     unsafe fn get_query_parameter_u32(&self, query: Self::Query, parameter: u32) -> u32 {
         let gl = &self.raw;
         let mut value = 0;
-        if gl.GetQueryBufferObjectiv_is_loaded() {
+        if gl.GetQueryObjectuiv_is_loaded() {
             gl.GetQueryObjectuiv(query.0.get(), parameter, &mut value);
         } else {
             gl.GetQueryObjectuivEXT(query.0.get(), parameter, &mut value);
@@ -4391,7 +4391,7 @@ impl HasContext for Context {
     unsafe fn get_query_parameter_u64(&self, query: Self::Query, parameter: u32) -> u64 {
         let gl = &self.raw;
         let mut value = 0;
-        if gl.GetQueryBufferObjectiv_is_loaded() {
+        if gl.GetQueryObjectui64v_is_loaded() {
             gl.GetQueryObjectui64v(query.0.get(), parameter, &mut value);
         } else {
             gl.GetQueryObjectui64vEXT(query.0.get(), parameter, &mut value);


### PR DESCRIPTION
I'm using GPU timers in my application and I discovered that it panics on my friend's macOS computer with this message:

```
location: /Users/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/glow-0.17.0/src/gl46.rs:4542:5
message: called glGetQueryObjectuivEXT but it was not loaded.
```

I don't own macOS and I don't really know GL that much, so I used AI (paid Codex with GPT-5.5) to create and find the fix. But I tried to do this responsibly, with MRE, so that we at least know that this fix works.

MRE is located here: https://github.com/optozorax/glow/tree/mre/query-object-readback-macos, along with github actions that run this MRE on macOS to test that it fails right now: https://github.com/optozorax/glow/actions/runs/25874883078. Here are screenshots if you can't access my GH actions:

<img width="675" height="278" alt="image" src="https://github.com/user-attachments/assets/d6683272-50d1-4369-b234-a3562fa94f1c" />

<img width="1245" height="413" alt="image" src="https://github.com/user-attachments/assets/ddd1fd0a-014c-4146-9801-86e1359a6c84" />

---

And this is the GH actions after the fix: https://github.com/optozorax/glow/tree/fix/query-object-readback-loader , https://github.com/optozorax/glow/actions/runs/25874892396

<img width="611" height="405" alt="image" src="https://github.com/user-attachments/assets/819e2d78-5218-469e-b3ec-42c3c0d2cc31" />

<img width="1246" height="309" alt="image" src="https://github.com/user-attachments/assets/61e4c65b-9229-47f4-92be-fb1e04acc91d" />

---

Looking at the code, the fix seems reasonable.