### PR TITLE
Support wasm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,12 @@ jobs:
     - run: cargo test --verbose
     - run: (cd examples/hello && cargo build --features glutin_winit)
     - run: (cd examples/hello && cargo build --target wasm32-unknown-unknown)
+    - name: wasm64
+      if: matrix.build == 'nightly'
+      run: |
+        rustup component add rust-src
+        cargo build --verbose --target wasm64-unknown-unknown -Z build-std=std,panic_abort
+        (cd examples/hello && cargo build --target wasm64-unknown-unknown -Z build-std=std,panic_abort)
     - name: sdl
       if: ${{ matrix.sdl == true }}
       run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,12 +33,12 @@ log = { version = "0.4.16", optional = true }
 debug_trace_calls = []
 debug_automatic_glGetError = []
 
-[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
+[target.'cfg(all(target_family = "wasm", not(target_os = "emscripten")))'.dependencies]
 js-sys = "~0.3"
 wasm-bindgen = "~0.2"
 slotmap = "1"
 
-[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies.web_sys]
+[target.'cfg(all(target_family = "wasm", not(target_os = "emscripten")))'.dependencies.web_sys]
 version = "~0.3.60"
 package = "web-sys"
 features = [
@@ -98,6 +98,12 @@ features = [
   "WebglLoseContext",
   "OvrMultiview2",
 ]
+
+# Wasm64 support requires a more recent version of the wasm-bindgen ecosystem
+[target.'cfg(all(target_arch = "wasm64", not(target_os = "emscripten")))'.dependencies]
+js-sys = "~0.3.100"
+wasm-bindgen = "~0.2.123"
+web_sys = { version = "~0.3.100", package = "web-sys" }
 
 [workspace]
 members = [

--- a/examples/hello/Cargo.toml
+++ b/examples/hello/Cargo.toml
@@ -6,20 +6,25 @@ edition = "2018"
 [dependencies]
 glow = { path = "../../" }
 
-[target.'cfg(not(any(target_arch = "wasm32")))'.dependencies]
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
 glutin = { version = "0.32.2", optional = true }
 glutin-winit = { version = "0.5.0", optional = true }
 winit = { version = "0.30.9", features = ["rwh_06"], optional = true }
 raw-window-handle = { version = "0.6.2", optional = true }
 sdl2 = { version = "0.37", optional = true }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(target_family = "wasm")'.dependencies]
 web-sys = { version = "0.3", features = [
     "HtmlCanvasElement",
     "WebGl2RenderingContext",
     "Window",
 ] }
 wasm-bindgen = { version = "0.2" }
+
+# Wasm64 support requires a more recent version of the wasm-bindgen ecosystem
+[target.'cfg(target_arch = "wasm64")'.dependencies]
+web-sys = "0.3.100"
+wasm-bindgen = "0.2.123"
 
 [features]
 glutin_winit = ["glutin", "glutin-winit", "winit", "raw-window-handle"]

--- a/examples/hello/README.md
+++ b/examples/hello/README.md
@@ -16,9 +16,16 @@ cargo run --features=sdl2
 
 ## Web
 
-`cd` to `examples/hello` directory
+`cd` to `examples/hello` directory.
 
-To run with web-sys:
+The `wasm-bindgen` CLI must match the `wasm-bindgen` crate version in
+`Cargo.lock`. Install the matching version with:
+
+```shell
+cargo install wasm-bindgen-cli --version <version-from-Cargo.lock>
+```
+
+### wasm32
 
 ```shell
 cargo build --target wasm32-unknown-unknown
@@ -26,3 +33,20 @@ mkdir -p generated
 wasm-bindgen ../../target/wasm32-unknown-unknown/debug/hello.wasm --out-dir generated --target web
 cp index.html generated
 ```
+
+### wasm64 (memory64)
+
+`wasm64-unknown-unknown` is a tier-3 target, so it requires a nightly toolchain
+and a from-source build of `std` (`-Z build-std`):
+
+```shell
+rustup toolchain install nightly --component rust-src
+cargo +nightly build --target wasm64-unknown-unknown -Z build-std=std,panic_abort
+mkdir -p generated
+wasm-bindgen ../../target/wasm64-unknown-unknown/debug/hello.wasm --out-dir generated --target web
+cp index.html generated
+```
+
+Open `generated/index.html` in a browser that supports the WebAssembly
+[memory64 proposal](https://caniuse.com/mdn-webassembly_memory64) (recent
+versions of Chrome and Firefox enable it by default).

--- a/examples/hello/index.html
+++ b/examples/hello/index.html
@@ -4,7 +4,6 @@
   </head>
   <body>
     <canvas id="canvas" width="640" height="480"></canvas>
-    <script src="./hello.js"></script>
     <script type="module">
       import init from "./hello.js";
 

--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -2,8 +2,8 @@ use glow::*;
 
 fn main() {
     unsafe {
-        // Create a context from a WebGL2 context on wasm32 targets
-        #[cfg(target_arch = "wasm32")]
+        // Create a context from a WebGL2 context on wasm targets
+        #[cfg(target_family = "wasm")]
         let (gl, shader_version) = {
             use wasm_bindgen::JsCast;
             let canvas = web_sys::window()
@@ -255,7 +255,7 @@ fn main() {
             }
         }
 
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         {
             // This could be called from `requestAnimationFrame`, a winit event
             // loop, etc.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,17 +12,17 @@ use std::collections::HashSet;
 mod version;
 pub use version::Version;
 
-#[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
+#[cfg(any(not(target_family = "wasm"), target_os = "emscripten"))]
 mod native;
-#[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
+#[cfg(any(not(target_family = "wasm"), target_os = "emscripten"))]
 pub use native::*;
-#[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
+#[cfg(any(not(target_family = "wasm"), target_os = "emscripten"))]
 mod gl46;
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+#[cfg(all(target_family = "wasm", not(target_os = "emscripten")))]
 #[path = "web_sys.rs"]
 mod web;
-#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+#[cfg(all(target_family = "wasm", not(target_os = "emscripten")))]
 pub use web::*;
 
 pub type Shader = <Context as HasContext>::Shader;


### PR DESCRIPTION
Relax the wasm cfg gates to `target_family = "wasm"` so the web-sys backend is selected for both wasm32 and wasm64.

Wasm64 is only a recent addition to wasm-bindgen so a more recent floor of wasm-bindgen is selected for those targeting wasm64.

Along for the ride, I updated the hello example with instructions on how to work it.